### PR TITLE
转圈搜索使用A+视角重置替换WASD

### DIFF
--- a/src/task/BaseCombatTask.py
+++ b/src/task/BaseCombatTask.py
@@ -78,8 +78,8 @@ class BaseCombatTask(BaseWWTask, FindFeature, OCR, CombatCheck):
         self.sleep(0.2)
 
     def run_in_circle_to_find_echo(self, circle_count=3):
-        directions = ['w', 'a', 's', 'd']
-        step = 1.2
+        directions = ['w', 'w', 'w', 'w']
+        step = 0.8
         duration = 0.8
         total_index = 0
         for count in range(circle_count):
@@ -92,6 +92,15 @@ class BaseCombatTask(BaseWWTask, FindFeature, OCR, CombatCheck):
                 if picked:
                     self.mouse_up(key="right")
                     return True
+                
+                self.sleep(0.1)
+                self.send_key_down('a')
+                self.sleep(0.01)
+                self.send_key_up('a')
+                self.sleep(0.1)
+                self.middle_click()
+                self.sleep(1)
+
                 total_index += 1
 
     def switch_next_char(self, current_char, post_action=None, free_intro=False, target_low_con=False):


### PR DESCRIPTION
鸣潮的A和D并不是径直左右走，而是边走边以每秒10°向左/右偏。按此方法WASD循环会导致轨迹逐渐右偏，搜索范围分布不均。这个PR改用A+鼠标中键重置视角，保证转向均为90°且每段轨迹为直线。

图：WASD的搜索轨迹
![image](https://github.com/user-attachments/assets/5890709c-cbd8-4988-a4b1-7930e0ce4950)
