### PR TITLE
修复多波怪间可能丢失索敌的问题

### DIFF
--- a/src/combat/CombatCheck.py
+++ b/src/combat/CombatCheck.py
@@ -157,6 +157,7 @@ class CombatCheck:
             now = time.time()
             if now - self.last_combat_check > self.combat_check_interval:
                 self.last_combat_check = now
+                self.reaim_enemy()
                 if check_team and not self.in_team()[0]:
                     logger.info('not in team break out of combat')
                     return self.reset_to_false(recheck=False, reason="not in team")
@@ -218,6 +219,12 @@ class CombatCheck:
             self.pause()
         return True
 
+    def reaim_enemy(self):
+        aim_percent = self.calculate_color_percentage(aim_color, self.get_box_by_name('box_target_enemy'))
+        if aim_percent == 0:
+            logger.info(f'Failed to focus the enemy, aim percent {aim_percent} ')
+            self.middle_click()
+            
     def target_enemy(self, wait=True):
         if not wait:
             self.middle_click()
@@ -324,6 +331,12 @@ boss_red_text_color = {
     'r': (200, 230),  # Red range
     'g': (70, 90),  # Green range
     'b': (60, 80)  # Blue range
+}
+
+aim_color = {
+    'r': (165, 175),  # Red range
+    'g': (150, 160),  # Green range
+    'b': (38, 48)  # Blue range
 }
 
 boss_health_color = {


### PR DESCRIPTION
战斗中多波次怪或者目标上天时可能导致丢失锁定，此时仍在战斗中，但是target_enemy位于in_combat中较后的位置被调用，因此不会重新锁定。从而会导致角色在离怪较远时撸墙甚至脱战。
在战斗中非开r时检查是否为已锁定状态，即box_target_enemy中是否存在深黄色，否则单击中键