### PR TITLE
解决报错 No module named 'ok.OK'

### DIFF
--- a/main_gpu.py
+++ b/main_gpu.py
@@ -1,6 +1,6 @@
 if __name__ == '__main__':
     from config import config
-    from ok.OK import OK
+    from ok import OK
 
     config = config
     config['ocr']['lib'] = 'paddleocr'


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "E:\game\miHoYo\GenshinImpactTool\ok-wuthering-waves\main_gpu.py", line 3, in <module>
    from ok.OK import OK
ModuleNotFoundError: No module named 'ok.OK'
```