### PR TITLE
传送后按下鼠标中键重置视角 reset camera after traval

### DIFF
--- a/src/task/FarmWorldBossTask.py
+++ b/src/task/FarmWorldBossTask.py
@@ -80,6 +80,8 @@ class FarmWorldBossTask(BaseCombatTask):
                         elif boss_name == 'Bell-Borne Geochelone':
                             logger.info(f'sleep for the Bell-Borne model to appear')
                             self.sleep(15)
+                        self.middle_click_relative(0.5, 0.5)
+                        self.sleep(0.4)
                         self.run_until(self.in_combat, 'w', time_out=10, running=True)
                         if boss_name == 'Sentry Construct':
                             logger.debug('Sentry Construct sleep')


### PR DESCRIPTION
>self.middle_click() 应该不用加参数
farmworldtask应该没在用了 之后删了 不用改
是不是应该click后sleep 1秒 等镜头回正

1.试了一下不传参，点开始，第一个设置异构武装，刚到场地就直接报错红×停止任务了
3.手动试了下鼠标中键和W+冲刺之间间隔0.4秒是够的，挂机一晚上没出现异构武装视野问题，但是看屏幕的时候，统计打了70多个，在骨龙前面任务停止了，没进作战场地，和平时传送到的位置一样，视角也一样，角色都活着，一点不动站在场地外，看起来一切是正常的，没看出来问题在哪。不知道是不是我改了导致的。_简单来说就是停在了骨龙面前，没走进去_