### PR TITLE
优化椿出招, 调整BaseCombatTask

### DIFF
--- a/src/task/BaseCombatTask.py
+++ b/src/task/BaseCombatTask.py
@@ -452,8 +452,23 @@ class BaseCombatTask(CombatCheck):
 
         # image_with_contours = image.copy()
 
+        blurred = cv2.GaussianBlur(image, (5, 5), 0)
+        
+        kernel = np.array([[0, -1, 0],
+                        [-1, 5, -1],
+                        [0, -1, 0]])
+        sharpened = cv2.filter2D(blurred, -1, kernel)
+
+        size = image.shape
+        center_x, center_y = size[1] // 2, size[0] // 2
+        r1, r2 = int(size[0]*0.3), int(size[0]*0.59)
+        cv2.circle(sharpened, (center_x, center_y), r1, 0, -1)
+        # cv2.circle(image_with_contours, (center_x, center_y), r1, 0, -1)
+        cv2.circle(sharpened, (center_x, center_y), r2, 0, r1)
+        # cv2.circle(image_with_contours, (center_x, center_y), r2, 0, r1)
+
         # Create a binary mask
-        mask = cv2.inRange(image, lower_bound, upper_bound)
+        mask = cv2.inRange(sharpened, lower_bound, upper_bound)
 
         # Find connected components
         num_labels, labels, stats, centroids = cv2.connectedComponentsWithStats(mask, connectivity=8)
@@ -525,8 +540,8 @@ white_color = {
 
 con_colors = [
     {
-        'r': (205, 235),
-        'g': (190, 222),  # for yellow spectro
+        'r': (205, 255),
+        'g': (190, 242),  # for yellow spectro
         'b': (90, 130)
     },
     {
@@ -535,14 +550,14 @@ con_colors = [
         'b': (210, 249)  # Blue range
     },
     {
-        'r': (200, 230),  # Red range
+        'r': (200, 240),  # Red range
         'g': (100, 130),  # Green range    for red fire
         'b': (75, 105)  # Blue range
     },
     {
-        'r': (60, 95),  # Red range
-        'g': (150, 180),  # Green range    for blue ice
-        'b': (210, 245)  # Blue range
+        'r': (50, 95),  # Red range
+        'g': (150, 185),  # Green range    for blue ice
+        'b': (210, 255)  # Blue range
     },
     {
         'r': (70, 110),  # Red range
@@ -550,7 +565,7 @@ con_colors = [
         'b': (155, 190)  # Blue range
     },
     {
-        'r': (190, 220),  # Red range
+        'r': (190, 240),  # Red range
         'g': (65, 105),  # Green range    for havoc
         'b': (145, 175)  # Blue range
     }


### PR DESCRIPTION
Camellya
输出改为使用长按普攻打出蔓舞派生，多次检测含苞状态，防止大招打断一日花
BaseCombatTask
调整has_intro的原因:
在切到椿时会进入`if current_index != switch_to.index:`然后再break会导致椿的has_intro永远是False。
调整get_current_con的原因:
connectedComponentsWithStats在协奏能量快满时容易把最后的3/4识别为不同的组件导致ring_count > 1的情况频繁发生，影响一日花判定。

备注: 本人只是代码新手要是哪里没写好直接作者调整就好