### PR TITLE
修复罗蕾莱在第三位时，白天无法自动调整时间的情况

### DIFF
--- a/src/task/FarmWorldBossTask.py
+++ b/src/task/FarmWorldBossTask.py
@@ -71,8 +71,8 @@ class FarmWorldBossTask(WWOneTimeTask, BaseCombatTask):
                             if not in_combat:  # try click again
                                 self.walk_until_f(raise_if_not_found=True, time_out=4)
                         elif boss_name == 'Lorelei':
-                            if count % 6 < 3:
-                                self.change_time_to_night()
+                            # if count % 6 < 3:
+                            self.change_time_to_night()
                         self.middle_click_relative(0.5, 0.5)
                         self.sleep(0.4)
                         self.run_until(self.in_combat, 'w', time_out=5, running=True)


### PR DESCRIPTION
在刷大世界4C声骸任务中，当罗蕾莱在第三顺位时无法自动调整时间，会卡一段时间并报错停止
![屏幕截图 2025-04-20 091519](https://github.com/user-attachments/assets/fda58e1e-b824-4eba-9dc1-b85045334b14)
![屏幕截图 2025-04-20 091630](https://github.com/user-attachments/assets/59e0fb75-49a5-4fea-96b9-a4dace561063)

检查代码，感觉count % 6 < 3这个条件和调整时间的动作没啥联系，所以先注释掉了