### PR TITLE
一些自动战斗逻辑BUG

### DIFF
--- a/src/task/BaseCombatTask.py
+++ b/src/task/BaseCombatTask.py
@@ -173,7 +173,7 @@ class BaseCombatTask(CombatCheck):
         logger.info(f'switch_next_char {current_char} -> {switch_to} has_intro {switch_to.has_intro}')
         last_click = 0
         start = time.time()
-        while True:            
+        while True:
             now = time.time()
             if now - last_click > 0.1:
                 self.send_key(switch_to.index + 1)


### PR DESCRIPTION
has_intro原先放在send_key后面存在误判，尤其现在开始有同色队后误判可能性高了不少，虽然没测试过还有没有误判的可能性，但放在前面应该会好一些
sleep_check_combat改成让check_combat先判断，不然很多时候使用self.sleep(0.xx,false)时，还是会被in_combat()打断