### PR TITLE
优化椿和散华

### DIFF
--- a/src/char/Camellya.py
+++ b/src/char/Camellya.py
@@ -1,4 +1,5 @@
 import time
+from decimal import Decimal, ROUND_HALF_UP
 
 from src.char.BaseChar import BaseChar, Priority
 
@@ -8,6 +9,13 @@ class Camellya(BaseChar):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.last_heavy = 0
+        self.waiting_for_forte_drop = False
+        self.forte_drop_timestamp = 0
+        self.forte_drop_reference = 0
+
+    def reset_state(self):
+        super().reset_state()
+        self.waiting_for_forte_drop = False
 
     def do_get_switch_priority(self, current_char: BaseChar, has_intro=False, target_low_con=False):
         if has_intro:
@@ -40,7 +48,10 @@ class Camellya(BaseChar):
     def do_perform(self):
         if self.has_intro:
             self.continues_normal_attack(1.2)
-        self.click_liberation(con_less_than=1)
+            self.sleep(0.1)
+            self.heavy_attack(4.6, until_con_full=True)
+        if self.liberation_available():
+            self.click_liberation(con_less_than=0.82)
         start_con = self.get_current_con()
         if start_con < 0.82:
             loop_time = 1.1
@@ -48,31 +59,49 @@ class Camellya(BaseChar):
             loop_time = 4.1
         budding_start_time = time.time()
         budding = False
-        full = False
+        heavy_att = False
         while time.time() - budding_start_time < loop_time or self.task.find_one('camellya_budding', threshold=0.7):
-            current_con = self.get_current_con()
-            if (start_con - current_con > 0.1) and not budding:
-                self.logger.info(f'confull start budding {current_con}')
-                budding_start_time = time.time()
-                loop_time = 5.1
-                budding = True
-            elif current_con == 1 and not budding and not full:
-                full = True
-                loop_time = 1
-                budding_start_time = time.time()
-            start_con = current_con
-            if self.click_resonance(send_click=False)[0]:
-                if self.get_current_con() < 0.82 and not budding:
-                    self.click_echo()
-                    return self.switch_next_char()
+            if not budding:
+                if self.ephemeral_ready():
+                    self.ephemeral_cast()
+                    budding = True
+                else:
+                    self.click(interval=0.1)
+                    current_con = self.get_current_con()
+                    if current_con < 0.82:
+                        self.click_resonance()
+                        self.sleep(0.1)
+                        if not self.is_con_full():
+                            self.click_echo()
+                            return self.switch_next_char()
+                        elif loop_time < 2.1:
+                            loop_time += 1
                 if budding:
-                    self.click_liberation()
-            else:
-                self.click(interval=0.1)
+                    self.logger.info(f'start budding')
+                    self.check_target()
+                    budding_start_time = time.time()
+                    loop_time = 5.1
+            if budding:
+                current_forte = self.get_forte(True)
+                if not heavy_att:
+                    heavy_att = True
+                    self.task.mouse_down()
+                if time.time() - budding_start_time < 1.5 and self.liberation_available():
+                    if self.click_liberation() and heavy_att:
+                        self.logger.info(f'liberation retry heavy att')
+                        self.sleep(0.2, False)
+                        self.task.mouse_down()
+            self.check_target(heavy_att)
             self.task.next_frame()
-            self.check_combat()
+            if heavy_att:
+                self.should_retry_heavy_attack(current_forte, True)
+        self.waiting_for_forte_drop = False
+        if heavy_att:
+            self.task.mouse_up()
+            self.sleep(0.1)
         if budding:
             self.click_resonance()
+            self.sleep(0.1)
         self.click_echo()
         self.switch_next_char()
 
@@ -80,4 +109,97 @@ class Camellya(BaseChar):
         if self.echo_available():
             self.send_echo_key()
             return True
+        
+    def ephemeral_ready(self):
+        box = self.task.box_of_screen_scaled(3840, 2160, 3149, 1832, 3225, 1857, name='camellya_resonance', hcenter=True)
+        red_percent = self.task.calculate_color_percentage(camellya_red_color, box)
+        self.logger.debug(f'red_percent {red_percent}')
+        return red_percent > 0.11
 
+    def ephemeral_cast(self):
+        self.check_combat()
+        while self.ephemeral_ready():
+            self.send_resonance_key()
+            self.sleep(0.1)
+        self.sleep(1.1)
+    
+    def get_forte(self, budding=False):
+        box = self.task.box_of_screen_scaled(3840, 2160, 1627, 1992, 2178, 2012, name='camellya_forte', hcenter=True)
+        forte_percent = 0
+        if not budding:
+            forte_percent = self.task.calculate_color_percentage(camellya_forte_color, box)
+            self.logger.debug(f'forte_percent {forte_percent}')
+        else:
+            forte_percent = self.task.calculate_color_percentage(camellya_budding_forte_color, box)
+            self.logger.debug(f'forte_percent_budding {forte_percent}')
+        forte_percent = Decimal(str(forte_percent)).quantize(Decimal('0.001'), rounding=ROUND_HALF_UP)
+        return forte_percent
+    
+    def heavy_attack(self, duration, check_combat = True, until_con_full = False):
+        self.logger.info(f'start heavy_attack')
+        self.task.mouse_down()
+        start = time.time()
+        while time.time() - start < duration:
+            current_forte = self.get_forte()
+            if until_con_full and self.is_con_full() or current_forte <= 0.01:
+                break
+            if check_combat:
+                self.check_target(True)
+            self.task.next_frame()
+            self.should_retry_heavy_attack(current_forte)
+        self.sleep(0.1, False)
+        self.task.mouse_up()
+        self.waiting_for_forte_drop = False
+
+    def should_retry_heavy_attack(self, current_forte, budding = False):
+        if not self.waiting_for_forte_drop:
+            diff = current_forte - self.get_forte(budding)
+            self.logger.debug(f'diff {diff}')
+            if diff <= 0.002:
+                self.waiting_for_forte_drop = True
+                self.forte_drop_timestamp = time.time()
+                if diff < 0:
+                    self.forte_drop_reference = current_forte - diff
+                else:
+                    self.forte_drop_reference = current_forte
+        else:
+            diff = self.forte_drop_reference - self.get_forte(budding)
+            self.logger.debug(f'drop_reference diff {diff}')
+            if diff > 0.002 or diff <= -0.007:
+                self.waiting_for_forte_drop = False
+            elif self.time_elapsed_accounting_for_freeze(self.forte_drop_timestamp) > 0.5:
+                self.logger.info(f'retry heavy attack')
+                self.task.mouse_up()
+                self.sleep(0.1, False)
+                self.task.mouse_down()
+                self.sleep(0.1, False)
+    
+    def check_target(self, is_heavy_att = False):
+        if not self.task.has_target():
+            if is_heavy_att:
+                self.logger.info(f'check_target Release')
+                self.task.mouse_up()
+            self.logger.info(f'check_combat')
+            self.check_combat()
+            self.task.next_frame()
+            if is_heavy_att:
+                self.logger.info(f'check_target Retry')
+                self.task.mouse_down()
+
+camellya_red_color = {
+    'r': (200, 250),  # Red range
+    'g': (60, 90),  # Green range
+    'b': (150, 190)   # Blue range
+} 
+
+camellya_forte_color = {
+    'r': (225, 255),  # Red range
+    'g': (40, 68),  # Green range
+    'b': (125, 149)   # Blue range
+} 
+
+camellya_budding_forte_color = {
+    'r': (251, 255),  # Red range
+    'g': (161, 200),  # Green range
+    'b': (181, 213)   # Blue range
+} 

--- a/src/char/Sanhua.py
+++ b/src/char/Sanhua.py
@@ -5,28 +5,28 @@ from src.char.BaseChar import BaseChar
 
 class Sanhua(BaseChar):
     def do_perform(self):
-        sleep_time = 0.65
-        self.sleep(0.02)
-        self.task.mouse_down()
-        self.sleep(0.1)
+        sleep_time = 0.8
+        if self.has_intro:
+            self.sleep(0.02)
         start = time.time()
+        self.task.mouse_down()
         if self.has_intro:
-            sleep_time -= 0.1
             self.wait_intro(click=False, time_out=1.1)
+        elif self.click_resonance(send_click=False):
+            self.sleep(0.1, False)
         if self.click_liberation(send_click=False):
-            sleep_time += 0.40
-            pass
-        clicked_resonance, duration, _ = self.click_resonance(send_click=False)
-        clicked_echo = self.click_echo()
+            sleep_time += 0.425
         sleep_time -= self.time_elapsed_accounting_for_freeze(start)
-        self.logger.debug('Sanhua to_sleep {}'.format(sleep_time))
-        self.sleep(sleep_time)
+        self.logger.info('Sanhua to_sleep {}'.format(sleep_time))
+        if sleep_time > 0:
+            self.sleep(sleep_time, False)
         self.task.mouse_up()
-        if clicked_resonance and not clicked_echo:
-            after_sleep = 0.6
-        else:
-            after_sleep = 0.3
+        self.sleep(0.6)
         if self.has_intro:
-            after_sleep += 0.8
-        self.sleep(after_sleep)
+            self.click_resonance(send_click=False)
+            self.sleep(0.3)
+        if self.get_current_con() == 1:
+            self.sleep(0.1)
+            self.click_echo()
+            self.sleep(0.05)
         self.switch_next_char()


### PR DESCRIPTION
椿: 解决一日花被大招覆盖，还有蔓舞派生被肘飞无法继续攻击的问题，还有就是打普攻和蔓舞派生出伤比较快
椿还是比较依赖is_con_full的精准度，当前的count_rings还是比较容易误判，例如ring_count > 1的情况，我目前是用了高斯模糊和涂黑非协奏能量区域来处里，看看有没有其他想法，或是就把我目前用的推上来
散华:重击·爆裂基本不失误，针对has_intro做出不同操作方式，散华变奏入场时间占比还是蛮高的，不变招会按过头
