### PR TITLE
ci: remove useless release note upload on released

### DIFF
--- a/.github/workflows/mirrorchyan_release_note.yml
+++ b/.github/workflows/mirrorchyan_release_note.yml
@@ -3,7 +3,7 @@ name: mirrorchyan_release_note
 on:
   workflow_dispatch:
   release:
-    types: [edited, released]
+    types: [edited]
 
 jobs:
   mirrorchyan_release_note:


### PR DESCRIPTION
release 的时候已经在 build.yml 里强制调用了，这个事件没啥用