### PR TITLE
优化长离船长，以及一些协同尝试

### DIFF
--- a/src/char/BaseChar.py
+++ b/src/char/BaseChar.py
@@ -766,6 +766,25 @@ class BaseChar:
                     return True
         return False
 
+    def check_outro(self):
+        """协奏入场时判断延奏来源
+
+        Returns:
+            string:非协奏入场返回'null'，否则范围角色名如'char_sanhua'
+        """
+        if not self.has_intro:
+            return 'null'
+        time = 0
+        outro = 'null'
+        for i, char in enumerate(self.task.chars):
+            if char == self:
+                pass
+            elif char.last_switch_time > time:
+                time = char.last_switch_time
+                outro = char.char_name
+        self.logger.info(f'erned outro from {outro}')
+        return outro 
+        
     # def count_rectangle_forte(self, left=0.42, right=0.57):
     # """计算矩形共鸣回路充能格数 (已注释)。"""
     #     # Perform image cropping once, as it's independent of saturation ranges

--- a/src/char/Brant.py
+++ b/src/char/Brant.py
@@ -16,27 +16,24 @@ class Brant(BaseChar):
 
     def do_perform(self):
         if self.has_intro:
-            self.continues_normal_attack(1)
+            self.continues_normal_attack(1.1)
         if self.is_forte_full() and self.resonance_available():
             self.resonance_forte_full()
             self.in_liberaction = 0
             self.perform_anchor = time.time()
             return self.switch_next_char()
-        if not self.need_fast_perform() and self.click_liberation():
+        if not self.need_fast_perform() and not self.is_forte_full() and self.click_liberation():
             self.liberaction_time = time.time()
             self.in_liberaction = 1
             self.continues_normal_attack(0.8)
-        if self.still_in_liberation():
-            self.click_jump_with_click(1.3)
-            if self.is_forte_full() and self.resonance_available():
-                self.resonance_forte_full()
-                self.perform_anchor = time.time()
-                self.in_liberaction = 0
-            return self.switch_next_char()
-        if self.echo_available():
+        if not self.still_in_liberation() and self.echo_available():
             self.click_echo()
-            return self.switch_next_char()
+            return self.switch_next_char()  
         self.click_jump_with_click(1.3)
+        if self.is_forte_full() and self.resonance_available():
+            self.resonance_forte_full()
+            self.perform_anchor = time.time()
+            self.in_liberaction = 0
         self.switch_next_char()
 
     def still_in_liberation(self):


### PR DESCRIPTION
船长：
1.现在会在切走前尝试释放e2
2.现在e2可使用时不会开大
长离：
1.优化e的实现
2.长离在吃到船长延奏时会尝试新的释放逻辑：
    3层离火时会普攻获得第四层离火
    尝试连续释放zrz
    重击会等到伤害跳出后再切走
    上述逻辑在能对上时会最大化利用船长的延奏（对不上就算了），但是会增加被肘概率，如果表现不佳会再做修改。
    另外船长协奏条超过80%时是否有必要延后zrz等露帕落地再进行调试