### PR TITLE
为打开地图加了等待

### DIFF
--- a/src/task/FarmEchoTask.py
+++ b/src/task/FarmEchoTask.py
@@ -127,9 +127,7 @@ class FarmEchoTask(WWOneTimeTask, BaseCombatTask):
             self.run_until(self.in_combat, 'w', time_out=12, running=True)
 
     def teleport_to_nearest_boss(self):
-        self.map_zoomed = False
-        self.zoom_map(esc=False)
-        self.wait_until(lambda: not self.in_team_and_world, raise_if_not_found=False, time_out=5)
+        self.send_key('m', after_sleep=1.5)
         boxes = self.find_feature(['boss_no_check_mark', 'boss_check_mark'], box=self.box_of_screen(0.3, 0.3, 0.7, 0.7),
                                   threshold=0.6)
         self.log_info(f'teleport_to_nearest_boss {boxes}')


### PR DESCRIPTION
如果网络延迟稍微高一点就会出现地图还没打开就到find_feature了

测试了一下打开地图的速度和延迟关系非常大
如果延迟高打开地图就会有一个比较高的延迟导致后面报错
所以尝试增加了这条不知道合不合理