### PR TITLE
声骸搜索优化

### DIFF
--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -335,11 +335,11 @@ class BaseWWTask(BaseTask):
         return self.find_one('new_realm_4') and self.in_realm() and self.find_one('illusive_realm_menu', threshold=0.6)
 
     def walk_until_f(self, direction='w', time_out=0, raise_if_not_found=True, backward_time=0, target_text=None,
-                     cancel=True):
-        #视角朝前
-        self.middle_click()
+                     cancel=True):        
         logger.info(f'walk_until_f direction {direction} target_text: {target_text}')
         if not self.find_f_with_text(target_text=target_text):
+            #视角朝前
+            self.middle_click(after_sleep=0.2)
             if backward_time > 0:
                 if self.send_key_and_wait_f('s', raise_if_not_found, backward_time, target_text=target_text):
                     logger.info('walk backward found f')

--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -336,6 +336,8 @@ class BaseWWTask(BaseTask):
 
     def walk_until_f(self, direction='w', time_out=0, raise_if_not_found=True, backward_time=0, target_text=None,
                      cancel=True):
+        #视角朝前
+        self.middle_click()
         logger.info(f'walk_until_f direction {direction} target_text: {target_text}')
         if not self.find_f_with_text(target_text=target_text):
             if backward_time > 0:

--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -335,7 +335,7 @@ class BaseWWTask(BaseTask):
         return self.find_one('new_realm_4') and self.in_realm() and self.find_one('illusive_realm_menu', threshold=0.6)
 
     def walk_until_f(self, direction='w', time_out=0, raise_if_not_found=True, backward_time=0, target_text=None,
-                     cancel=True):        
+                     cancel=True):
         logger.info(f'walk_until_f direction {direction} target_text: {target_text}')
         if not self.find_f_with_text(target_text=target_text):
             #视角朝前


### PR DESCRIPTION
声骸搜索，后退在前进，杀死boss后（卡提打boss卡提，其他未试），视角会旋转，导致无法正确朝地点搜索，所以增加了一次鼠标中间，用于视角向前。