### PR TITLE
修正一些liberation_available的判断条件

### DIFF
--- a/src/char/BaseChar.py
+++ b/src/char/BaseChar.py
@@ -678,9 +678,9 @@ class BaseChar:
         Returns:
             bool: 如果可用则返回 True。
         """
-        if self._liberation_available:
-            return True
         if self.is_current_char:
+            if self._liberation_available and not self.has_cd('liberation'):
+                return True
             snap = self.current_liberation()
             if snap == 0:
                 return False


### PR DESCRIPTION
update_lib_portrait_icon的判断似乎有些过了，经常大招cd/充能没好就设了self._liberation_available=True，不知道是不是被背景干扰了。 
总之对于前台角色在原基础上再添加一个self.has_cd('liberation')的检测能解决一部分问题。
has_cd还是很准确的，毕竟大招cd的时候并不会泛光