### PR TITLE
添加pc网页端云鸣潮支持

### DIFF
--- a/config.py
+++ b/config.py
@@ -67,13 +67,19 @@ monthly_card_config_option = ConfigOption('Monthly Card Config', {
     'Monthly Card Time': 'Your computer\'s local time when the monthly card will popup, hour in (1-24)'
 })
 
+cloud_config_option = ConfigOption('Cloud Config', {
+    'Color for Cloud Wuwa': False
+}, description='Setting for Cloud Wuwa', config_description={
+    'Color for Cloud Wuwa': 'Color in Cloud Wuwa may be unreal. Turn on for adjust the color setting'
+})
+
 config = {
     'debug': False,  # Optional, default: False
     'use_gui': True,
     'config_folder': 'configs',
     'screenshot_processor': make_bottom_right_black,
     'gui_icon': 'icon.png',
-    'global_configs': [key_config_option, pick_echo_config_option, monthly_card_config_option],
+    'global_configs': [key_config_option, pick_echo_config_option, monthly_card_config_option, cloud_config_option],
     'ocr': {
         'lib': 'onnxocr'
     },

--- a/main_cloud.py
+++ b/main_cloud.py
@@ -1,0 +1,15 @@
+if __name__ == '__main__':
+    from config import config
+    from ok import OK
+    from ok import ConfigOption
+
+    config = config
+    del config['windows']['hwnd_class']
+    del config['windows']['calculate_pc_exe_path']
+    config['windows']['exe'] = ['chrome.exe', 'msedge.exe']
+        'Color for Cloud Wuwa': True
+        }, description='Setting for Cloud Wuwa', config_description={
+        'Color for Cloud Wuwa': 'Color in Cloud Wuwa may be unreal. Turn on for adjust the color setting'
+    config['global_configs'][3] = cloud_config_option
+    ok = OK(config)
+    ok.start()

--- a/main_cloud_debug.py
+++ b/main_cloud_debug.py
@@ -1,0 +1,16 @@
+if __name__ == '__main__':
+    from config import config
+    from ok import OK
+    from ok import ConfigOption
+
+    config = config
+    del config['windows']['hwnd_class']
+    del config['windows']['calculate_pc_exe_path']
+    config['debug'] = True
+    config['windows']['exe'] = ['chrome.exe', 'msedge.exe']
+        'Color for Cloud Wuwa': True
+        }, description='Setting for Cloud Wuwa', config_description={
+        'Color for Cloud Wuwa': 'Color in Cloud Wuwa may be unreal. Turn on for adjust the color setting'
+    config['global_configs'][3] = cloud_config_option
+    ok = OK(config)
+    ok.start()

--- a/src/combat/CombatCheck.py
+++ b/src/combat/CombatCheck.py
@@ -30,6 +30,7 @@ class CombatCheck(BaseWWTask):
         self.target_enemy_time_out = 3
         self.combat_end_condition = None
         self._in_illusive = False
+        self.cload_config = self.get_global_config('Cloud Config')
 
     @property
     def in_liberation(self):
@@ -180,8 +181,11 @@ class CombatCheck(BaseWWTask):
         else:
             outer_box = 'box_target_enemy'
             inner_box = 'box_target_enemy_inner'
-        aim_percent = self.calculate_color_percentage(aim_color, self.get_box_by_name(outer_box))
-        aim_inner_percent = self.calculate_color_percentage(aim_color, self.get_box_by_name(inner_box))
+        color = aim_color
+        if self.cload_config.get('Cloud'):
+            color = cloud_aim_color
+        aim_percent = self.calculate_color_percentage(color, self.get_box_by_name(outer_box))
+        aim_inner_percent = self.calculate_color_percentage(color, self.get_box_by_name(inner_box))
         # logger.debug(f'box_target_enemy yellow percent {aim_percent} {aim_inner_percent}')
         if aim_percent - aim_inner_percent > 0.02:
             return True


### PR DESCRIPTION
使用python main_cloud.py打开
目前只支持chrome和edge浏览器，通过F11全屏等方式切换无界面浏览器后可以使用，另外需要在云鸣潮游戏菜单中隐藏上方的fps显示。
pc端的颜色失真严重，目前只验证了自动战斗和自动刷c4的功能，并且目前不支持自动选取小怪

PS.ok_script有没有什么接口能向combatCheck传递config信息的，我实在没办法才加了个global_config栏。