### PR TITLE
禁用火属性角色通过update_lib_portrait_icon判断是否满大

### DIFF
--- a/src/task/BaseCombatTask.py
+++ b/src/task/BaseCombatTask.py
@@ -744,6 +744,9 @@ class BaseCombatTask(CombatCheck):
         for i in range(len(self.chars)):
             char_index = i + 1
             char = self.chars[i]
+            # 热熔属性角色误判较多
+            if char.ring_index == 'lib_ready_fire':
+                continue
             if not char.is_current_char and char.ring_index >= 0 and not char._liberation_available:
                 box = self.get_box_by_name("lib_mark_char_{}".format(char_index))
                 match = self.find_one(lib_ready_templates[char.ring_index], box=box, threshold=0.45)


### PR DESCRIPTION
find one对火属性的角标有很严重的错判。无解放条满的角标时也经常能识别到box，甚至confidence能到60以上. 该问题目前只出现在火属性角色身上，目前没有找到什么好的区分办法，认为此处禁用火属性角色比较合适