### PR TITLE
add debug support for vscode (with python extention)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Release",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/main.py",
+      "console": "integratedTerminal",
+    },
+    {
+      "name": "Debug",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/main_debug.py",
+      "console": "integratedTerminal",
+    },
+    {
+      "name": "po2mo (i18n)",
+      "type": "PowerShell",
+      "request": "launch",
+      "script": "cd ${workspaceFolder}/i18n/en_US/LC_MESSAGES && msgfmt.exe -o ok.mo ok.po && cd ../../zh_CN/LC_MESSAGES && msgfmt.exe -o ok.mo ok.po",
+    },
+  ]
+}


### PR DESCRIPTION
旨在方便使用 VSCode 开发调试。

可以在 VSCode 的 Run and Debug 中运行，并进行断点调试。（为了确保窗口识别，VSCode 需要已管理员权限运行。）

po2mo 命令可以将 i18n 下面的 po 文本文件转换成 mo 二进制文件。**使用前需要用 MinGW 安装 gettext 。**

