### PR TITLE
优化刷带treasure声骸时的一些问题

### DIFF
--- a/src/task/FarmEchoTask.py
+++ b/src/task/FarmEchoTask.py
@@ -90,6 +90,10 @@ class FarmEchoTask(WWOneTimeTask, BaseCombatTask):
             self.log_info('start wait in combat')
             if not self._in_realm and not self._has_treasure and not self.in_combat():
                 self.go_to_boss_minimap()
+                if not self.in_combat() and self.find_treasure_icon() and self.walk_to_treasure_and_restart():
+                    self._has_treasure = True
+                    self.log_info('_has_treasure = True')
+                    self.scroll_and_click_buttons()                  
 
             self.sleep(self.config.get("Combat Wait Time", 0))
 
@@ -136,7 +140,7 @@ class FarmEchoTask(WWOneTimeTask, BaseCombatTask):
         if not self.in_combat():
             self.teleport_to_nearest_boss()
             self.sleep(0.5)
-            self.run_until(self.in_combat, 'w', time_out=12, running=True)
+            self.run_until(lambda: self.in_combat() or self.find_treasure_icon(), 'w', time_out=12, running=True)
 
     def teleport_to_nearest_boss(self):
         self.send_key('m', after_sleep=2)
@@ -152,6 +156,9 @@ class FarmEchoTask(WWOneTimeTask, BaseCombatTask):
     def scroll_and_click_buttons(self):
         self.sleep(0.2)
         start = time.time()
+        if self._has_treasure and not self.find_f_with_text():
+            self.scroll_relative(0.5, 0.5, 1)
+            self.sleep(0.2)
         while self.find_f_with_text() and not self.in_combat() and time.time() - start < 5:
             self.log_info('scroll_and_click_buttons')
             self.scroll_relative(0.5, 0.5, 1)


### PR DESCRIPTION
1.如果声骸吸收和重新挑战同时出现并且吸收在重新挑战下面时，scroll_and_click_buttons会点到吸收然后处于下图的这个位置
![QQ图片20250709011047](https://github.com/user-attachments/assets/8b8af55e-b802-4474-8c4a-9c514af9b263)
这个时候框小了识别不到F键会卡住，159~161行会多滚轮一次以让F回到最上面，当然增加F的识别范围也可以解决这个问题

2.如果treasure阶段触发了go_to_boss_minimap，传送后boss并不会刷新。因此run_until时应该同时识别treasure_icon和in_combat
