### PR TITLE
fix a bug in add stamina

### DIFF
--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -438,11 +438,11 @@ class BaseWWTask(BaseTask):
             self.wait_ocr(0.6, 0.53, 0.66, 0.62, match=number_re, raise_if_not_found=True)[0].name)
         to_minus = back_up - to_add
         self.log_info(f'add_stamina, to_minus:{to_minus}, to_add:{to_add}, back_up:{back_up}')
-        if to_minus > 0:
-            for _ in range(to_minus):
+        
+        for _ in range(abs(to_minus)):
+            if to_minus > 0:
                 self.click(0.24, 0.58, after_sleep=0.01) # -
-        elif to_minus < 0:
-            for _ in range(-to_minus):
+            else:           
                 self.click(0.69, 0.58, after_sleep=0.01) # +
         self.click_relative(0.69, 0.71, after_sleep=2)
         self.info_set('add_stamina', to_add)

--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -438,8 +438,12 @@ class BaseWWTask(BaseTask):
             self.wait_ocr(0.6, 0.53, 0.66, 0.62, match=number_re, raise_if_not_found=True)[0].name)
         to_minus = back_up - to_add
         self.log_info(f'add_stamina, to_minus:{to_minus}, to_add:{to_add}, back_up:{back_up}')
-        for _ in range(to_minus):
-            self.click(0.24, 0.58, after_sleep=0.01)
+        if to_minus > 0:
+            for _ in range(to_minus):
+                self.click(0.24, 0.58, after_sleep=0.01) # -
+        elif to_minus < 0:
+            for _ in range(-to_minus):
+                self.click(0.69, 0.58, after_sleep=0.01) # +
         self.click_relative(0.69, 0.71, after_sleep=2)
         self.info_set('add_stamina', to_add)
         self.back(after_sleep=1)


### PR DESCRIPTION
观察日志

```
2025-07-17 07:47:42,120 INFO TaskExecutor DailyTask:info_set current_stamina 0
2025-07-17 07:47:42,120 INFO TaskExecutor DailyTask:info_set back_up_stamina 214
2025-07-17 07:47:45,279 INFO TaskExecutor DailyTask:add_stamina, to_minus:-60, to_add:120, back_up:60
2025-07-17 07:47:47,780 INFO TaskExecutor DailyTask2:info_set add_stamina 120
```

发现 `to_minus` 为负数，导致 `add_stamina` 增加的体力与输入不一致，导致后续处理出错。

研究发现，游戏取出体力最大为 40/60，所以上述情况下页面初始化显示的后备体力增加数为 60，然而实际需要取出 120。

这个 pr 处理了这种情况，如果 `to_minus` 为负数，则在后备体力页面上点击加号增加体力到所需。
