### PR TITLE
fix a bug

### DIFF
--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -400,14 +400,14 @@ class BaseWWTask(BaseTask):
         self.info_set('back_up_stamina', back_up)
         return current, back_up
 
-    def use_stamina(self, once):
+    def use_stamina(self, once, force_once = False):
         self.sleep(1)
         texts = self.ocr(0.2, 0.56, 0.75, 0.69, match=[number_re])
         min_stamina_box = self.find_boxes(texts, match=[re.compile(str(once))])
         if not min_stamina_box:
             min_stamina_box = self.box_of_screen(0.65, 0.61, 0.66, 0.62)  # 有双倍
         min_stamina = once
-        if max_stamina_box := self.find_boxes(texts, match=[re.compile(str(once * 2))]):
+        if max_stamina_box := self.find_boxes(texts, match=[re.compile(str(once * 2))]) and not force_once:
             max_stamina = once * 2
         else:
             max_stamina_box = min_stamina_box

--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -400,18 +400,20 @@ class BaseWWTask(BaseTask):
         self.info_set('back_up_stamina', back_up)
         return current, back_up
 
-    def use_stamina(self, once, force_once = False):
+    def use_stamina(self, once, max_count=100):
         self.sleep(1)
         texts = self.ocr(0.2, 0.56, 0.75, 0.69, match=[number_re])
         min_stamina_box = self.find_boxes(texts, match=[re.compile(str(once))])
         if not min_stamina_box:
             min_stamina_box = self.box_of_screen(0.65, 0.61, 0.66, 0.62)  # 有双倍
         min_stamina = once
-        if max_stamina_box := self.find_boxes(texts, match=[re.compile(str(once * 2))]) and not force_once:
+        if max_stamina_box := self.find_boxes(texts, match=[re.compile(str(once * 2))]):
             max_stamina = once * 2
         else:
             max_stamina_box = min_stamina_box
             max_stamina = once
+
+        max_stamina = min(max_stamina, max_count * once)
 
         current, back_up = self.get_stamina()
         if not self.farm_task_config.get('Use Waveplate Crystal'):
@@ -441,12 +443,12 @@ class BaseWWTask(BaseTask):
             self.wait_ocr(0.6, 0.53, 0.66, 0.62, match=number_re, raise_if_not_found=True)[0].name)
         to_minus = back_up - to_add
         self.log_info(f'add_stamina, to_minus:{to_minus}, to_add:{to_add}, back_up:{back_up}')
-        
+
         for _ in range(abs(to_minus)):
             if to_minus > 0:
-                self.click(0.24, 0.58, after_sleep=0.01) # -
-            else:           
-                self.click(0.69, 0.58, after_sleep=0.01) # +
+                self.click(0.24, 0.58, after_sleep=0.01)  # -
+            else:
+                self.click(0.69, 0.58, after_sleep=0.01)  # +
         self.click_relative(0.69, 0.71, after_sleep=2)
         self.info_set('add_stamina', to_add)
         self.back(after_sleep=1)

--- a/src/task/DomainTask.py
+++ b/src/task/DomainTask.py
@@ -52,7 +52,7 @@ class DomainTask(WWOneTimeTask, BaseCombatTask):
             self.sleep(3)
             self.walk_to_treasure()
             self.pick_f(handle_claim=False)
-            used, remaining_total, remaining_current, _ = self.use_stamina(self.stamina_once)
+            used, remaining_total, remaining_current, _ = self.use_stamina(once=self.stamina_once, force_once=(counter <= 1))
             if used == 0:
                 self.log_info(f'not enough stamina')
                 self.back()

--- a/src/task/DomainTask.py
+++ b/src/task/DomainTask.py
@@ -52,7 +52,7 @@ class DomainTask(WWOneTimeTask, BaseCombatTask):
             self.sleep(3)
             self.walk_to_treasure()
             self.pick_f(handle_claim=False)
-            used, remaining_total, remaining_current, _ = self.use_stamina(once=self.stamina_once, force_once=(counter <= 1))
+            used, remaining_total, remaining_current, _ = self.use_stamina(once=self.stamina_once, max_count=counter)
             if used == 0:
                 self.log_info(f'not enough stamina')
                 self.back()

--- a/src/task/TacetTask.py
+++ b/src/task/TacetTask.py
@@ -74,7 +74,7 @@ class TacetTask(WWOneTimeTask, BaseCombatTask):
             self.sleep(3)
             self.walk_to_treasure()
             self.pick_f(handle_claim=False)
-            used, remaining_total, remaining_current, _ = self.use_stamina(once=self.stamina_once, force_once=(counter <= 1))
+            used, remaining_total, remaining_current, _ = self.use_stamina(once=self.stamina_once, max_count=counter)
             if used == 0:
                 return self.not_enough_stamina()
             total_used += used

--- a/src/task/TacetTask.py
+++ b/src/task/TacetTask.py
@@ -74,7 +74,7 @@ class TacetTask(WWOneTimeTask, BaseCombatTask):
             self.sleep(3)
             self.walk_to_treasure()
             self.pick_f(handle_claim=False)
-            used, remaining_total, remaining_current, _ = self.use_stamina(self.stamina_once)
+            used, remaining_total, remaining_current, _ = self.use_stamina(once=self.stamina_once, force_once=(counter <= 1))
             if used == 0:
                 return self.not_enough_stamina()
             total_used += used


### PR DESCRIPTION
当凝素领域设置为3次，剩余体力为160时，脚本执行2次双倍，使用160体力。

预期是：脚本执行1次双倍+1次单倍，使用120体力。

这个 PR 旨在修复这个bug。