### PR TITLE
优化若干角色

### DIFF
--- a/src/char/Cantarella.py
+++ b/src/char/Cantarella.py
@@ -30,7 +30,7 @@ class Cantarella(BaseChar):
         count = -0.1
         while self.time_elapsed_accounting_for_freeze(self.last_heavy) < 8 and not self.is_mouse_forte_full():
             now = time.time()
-            if self.resonance_available and self.click_resonance(send_click=False):
+            if self.resonance_available() and self.click_resonance(send_click=False):
                 if not perform_under_outro:
                     self.task.mouse_up()
                     return self.switch_next_char() 
@@ -58,7 +58,7 @@ class Cantarella(BaseChar):
         
     def on_combat_end(self, chars):
         next_char = str((self.index + 1) % len(chars) + 1)
-        self.logger.debug(f'Camellya on_combat_end {self.index} switch next char: {next_char}')
+        self.logger.debug(f'Cantarella on_combat_end {self.index} switch next char: {next_char}')
         self.task.send_key(next_char)
 
     def is_forte_full(self):

--- a/src/char/Cantarella.py
+++ b/src/char/Cantarella.py
@@ -1,88 +1,74 @@
 import time
-from src.char.BaseChar import BaseChar, forte_white_color
+from src.char.BaseChar import BaseChar, forte_white_color, Priority
 
 
 class Cantarella(BaseChar):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.last_forte = 0
-
-    def reset_state(self):
-        super().reset_state()
-        self.last_forte = 0
+        self.last_heavy = -1
 
     def do_perform(self):
-        heavy_ready = False
-        self.logger.info(f'forte_cd {self.time_elapsed_accounting_for_freeze(self.last_forte)}')
+        perform_under_outro = False
         if self.has_intro:
             self.continues_normal_attack(1.2)
-            heavy_ready = True
-        if self.click_resonance()[0]:
-            heavy_ready = True
-        if self.click_liberation():
-            heavy_ready = True
-        if not self.need_fast_perform() and self.is_forte_full() and self.forte_ready() and heavy_ready:
-            self.heavy_attack_combo()
-            return self.switch_next_char()
-        if self.echo_available():
-            self.click_echo()
-            return self.switch_next_char()
-        self.continues_normal_attack(0.1)
-        self.switch_next_char()
-
-    def forte_ready(self):
-        return self.time_elapsed_accounting_for_freeze(self.last_forte) > 18
-
-    def heavy_attack_combo(self):
-        start = time.time()
-        forte_delay = start
-        self.heavy_attack(1.2)
-        click = 0
-        while self.forte_ready():
-            if time.time() - start > 8:
-                break
-            if self.is_forte_full():
-                forte_delay = time.time()
-            elif time.time() - forte_delay > 0.5:
-                break
-            if click == 0:
-                self.click()
+            if self.check_outro() in {'char_roccia', 'char_sanhua', 'char_sanhua2'}:
+                perform_under_outro = True
+        self.click_liberation()
+        if self.is_mouse_forte_full() or not self.is_forte_full():
+            self.click_resonance()
+            if perform_under_outro and self.flying():
+                self.wait_down()
+            if not self.flying() and self.is_mouse_forte_full():
+                if self.heavy_click_forte(check_fun=self.is_mouse_forte_full):
+                    self.last_heavy = time.time()
+            elif self.click_echo():
+                return self.switch_next_char()
             else:
-                self.send_resonance_key()
-            click = 1 - click
+                self.continues_normal_attack(0.1)
+                return self.switch_next_char()             
+        forte_delay = time.time()
+        count = -0.1
+        while self.time_elapsed_accounting_for_freeze(self.last_heavy) < 8 and not self.is_mouse_forte_full():
+            now = time.time()
+            if self.resonance_available and self.click_resonance(send_click=False):
+                if not perform_under_outro:
+                    self.task.mouse_up()
+                    return self.switch_next_char() 
+            if not perform_under_outro and self.need_fast_perform() and self.time_elapsed_accounting_for_freeze(self.last_perform) > 1.1:
+                break 
+            if now - forte_delay > count:
+                self.task.mouse_up()
+                self.sleep(0.2)
+                self.task.mouse_down()
+                count += 1
+            if self.is_forte_full():
+                forte_delay = now
+            elif now - forte_delay > 0.5:
+                break
             self.check_combat()
             self.task.next_frame()
-        self.last_forte = time.time()
+        self.task.mouse_up()
+        self.click_echo()
+        self.switch_next_char()
+            
+    def resonance_available(self, current=None, check_ready=False, check_cd=False):
+        if not self.is_mouse_forte_full() and self.is_forte_full():
+            return not self.has_cd('resonance')
+        return super().resonance_available()
+        
+    def on_combat_end(self, chars):
+        next_char = str((self.index + 1) % len(chars) + 1)
+        self.logger.debug(f'Camellya on_combat_end {self.index} switch next char: {next_char}')
+        self.task.send_key(next_char)
 
     def is_forte_full(self):
-        box = self.task.box_of_screen_scaled(3840, 2160, 2251, 1993, 2311, 2016, name='forte_full', hcenter=True)
+        box = self.task.box_of_screen_scaled(5120, 2880, 3034, 2640, 3090, 2700, name='forte_full', hcenter=True)
         white_percent = self.task.calculate_color_percentage(forte_white_color, box)
-        # self.logger.info(f'forte_color_percent {white_percent}')
-        return white_percent > 0.03
+        self.logger.debug(f'forte_color_percent {white_percent}')
+        return white_percent > 0.06
+        
+    def do_get_switch_priority(self, current_char: BaseChar, has_intro=False, target_low_con=False):
+        if has_intro and current_char.char_name in {'char_roccia', 'char_sanhua', 'char_sanhua2'}:
+            return Priority.MAX-1
+        return super().do_get_switch_priority(current_char, has_intro)
 
-    ##########################
-    def resonance_havoc(self):
-        box = self.task.box_of_screen_scaled(3840, 2160, 3105, 1845, 3285, 2010, name='cantarella_resonance',
-                                             hcenter=True)
-        havoc_percent = self.task.calculate_color_percentage(cantarella_havoc_color, box)
-        self.logger.info(f'cantarella_havoc_color_percent {havoc_percent}')
-        return havoc_percent > 0.01
-
-    def resonance_until_not_havoc(self):
-        start = time.time()
-        b = False
-        while self.resonance_havoc() or time.time() - start < 0.5:
-            self.task.send_resonance_key()
-            b = True
-            if time.time() - start > 2:
-                return False
-            self.check_combat()
-            self.task.next_frame()
-        return b
-
-
-cantarella_havoc_color = {
-    'r': (225, 255),  # Red range
-    'g': (60, 90),  # Green range
-    'b': (160, 190)  # Blue range
-}

--- a/src/char/Carlotta.py
+++ b/src/char/Carlotta.py
@@ -245,7 +245,7 @@ class Carlotta(BaseChar):
         self.char_zhezhi.forte = 0
         self.get_forte()
         if not self.liberation_ready:
-            while not self.is_mouse_forte_full()():
+            while not self.is_mouse_forte_full():
                 if self.resonance_available():
                     self.click_resonance()
                 else:

--- a/src/char/Carlotta.py
+++ b/src/char/Carlotta.py
@@ -35,7 +35,7 @@ class Carlotta(BaseChar):
             self.logger.debug('has_intro wait click 1.3 sec')
             self.bullet = 1
             self.continues_normal_attack(1.3)
-        if self.heavy_click_forte():
+        if self.heavy_click_forte(check_fun = self.is_mouse_forte_full):
             return self.switch_next_char()
         if self.liberation_available() and not self.need_fast_perform():
             if self.press_w == 1:
@@ -199,7 +199,7 @@ class Carlotta(BaseChar):
             self.char_zhezhi.char_carlotta = self
 
     def get_forte(self):
-        if self.is_forte_full():
+        if self.is_mouse_forte_full():
             return 4
         box = self.task.box_of_screen_scaled(5120, 2880, 2164, 2670, 2900, 2680, name='carlotta_forte', hcenter=True)
         self.forte = self.calculate_forte_num(carlotta_forte_color, box, 4, 9, 11, 100)
@@ -226,7 +226,7 @@ class Carlotta(BaseChar):
                 return self.switch_next_char()
         if self.get_ready():
             self.continue_liberation = False
-        if self.heavy_click_forte():
+        if self.heavy_click_forte(check_fun = self.is_mouse_forte_full):
             self.liberation_ready = True
             return self.switch_next_char()
         if self.liberation_available() and self.continue_liberation:
@@ -245,7 +245,7 @@ class Carlotta(BaseChar):
         self.char_zhezhi.forte = 0
         self.get_forte()
         if not self.liberation_ready:
-            while not self.is_forte_full():
+            while not self.is_mouse_forte_full()():
                 if self.resonance_available():
                     self.click_resonance()
                 else:
@@ -253,7 +253,7 @@ class Carlotta(BaseChar):
                 if self.time_elapsed_accounting_for_freeze(self.last_perform) > 6:
                     break
                 self.check_combat()
-        if self.heavy_click_forte():
+        if self.heavy_click_forte(check_fun = self.is_mouse_forte_full):
             self.liberation_ready = True
             self.forte = 0
         self.check_combat()

--- a/src/char/Changli.py
+++ b/src/char/Changli.py
@@ -37,7 +37,7 @@ class Changli(BaseChar):
         if forte == 4 or self.is_mouse_forte_full():
             if self.current_tool() < 0.1:
                 self.heavy_attack()
-            self.heavy_click_forte()
+            self.heavy_click_forte(check_fun = self.is_mouse_forte_full)
             forte = 0
             self.check_combat()
             return self.switch_next_char()
@@ -70,12 +70,12 @@ class Changli(BaseChar):
                 self.check_combat()
                 self.task.next_frame()
             if self.is_mouse_forte_full():
-                self.heavy_click_forte()
+                self.heavy_click_forte(check_fun = self.is_mouse_forte_full)
                 self.sleep(1)
         elif forte >= 4 or self.is_mouse_forte_full():
             if self.current_tool() < 0.1:
                 self.heavy_attack()
-            self.heavy_click_forte()
+            self.heavy_click_forte(check_fun = self.is_mouse_forte_full)
             forte = 0
             self.sleep(1)
         if self.liberation_available() and self.liberation_and_heavy():

--- a/src/char/Ciaccona.py
+++ b/src/char/Ciaccona.py
@@ -35,7 +35,7 @@ class Ciaccona(BaseChar):
                 self.continues_normal_attack(0.7)
         if self.current_echo() < 0.22:
             self.click_echo(time_out=0)
-        if not self.has_intro and not self.need_fast_perform() and not self.is_forte_full():
+        if not self.has_intro and not self.need_fast_perform() and not self.is_mouse_forte_full():
             self.click_jump_with_click(0.4)
             self.task.wait_until(lambda: not self.flying(), post_action=self.click_with_interval, time_out=1.2)
             self.continues_normal_attack(0.2)
@@ -50,7 +50,7 @@ class Ciaccona(BaseChar):
                     if time.time()-start > 0.3:
                         break
                     self.task.next_frame() 
-            self.heavy_attack()
+            self.heavy_click_forte(check_fun = self.is_mouse_forte_full)
             wait = True
         if self.liberation_available(): 
             if wait:
@@ -92,7 +92,7 @@ class Ciaccona(BaseChar):
             self.task.send_key(key='a')
 
     def judge_forte(self):
-        if self.is_forte_full():
+        if self.is_mouse_forte_full():
             return 3
         box = self.task.box_of_screen_scaled(3840, 2160, 1612, 1987, 2188, 2008, name='ciaccona_forte', hcenter=True)
         forte = self.calculate_forte_num(ciaccona_forte_color, box, 3, 12, 14, 100)

--- a/src/char/HavocRover.py
+++ b/src/char/HavocRover.py
@@ -39,7 +39,7 @@ class HavocRover(BaseChar):
         self.wait_down()
         self.spectro_routine_aftertune_combo()
         self.click_echo(time_out=0)
-        if self.is_mouse_forte_full():
+        if self.is_forte_full():
             self.check_combat()
             if self.resonance_available() and self.click_resonance()[0]:
                 self.continues_normal_attack(1.4)
@@ -55,7 +55,7 @@ class HavocRover(BaseChar):
 
     def perform_havoc_routine(self):
         self.wait_down()
-        self.heavy_click_forte()
+        self.heavy_click_forte(check_fun = self.is_mouse_forte_full)
         self.click_liberation(send_click=True)
         if self.click_resonance(send_click=True)[0]:
             return
@@ -77,7 +77,7 @@ class HavocRover(BaseChar):
                 self.wind_routine_wait_down()
                 return
         self.wind_routine_wait_down(check_forte_full=False)
-        if self.resonance_available() and not self.is_mouse_forte_full():
+        if self.resonance_available() and not self.is_forte_full():
             self.click_echo(time_out=0)
             start = time.time()
             flying = False
@@ -122,7 +122,7 @@ class HavocRover(BaseChar):
                                      post_action=lambda: self.click(interval=0.1, after_sleep=0.01), time_out=2.5)
         if check_forte_full:
             self.sleep(0.03)
-            if self.is_mouse_forte_full():
+            if self.is_forte_full():
                 self.send_resonance_key()
         else:
             self.sleep(0.01)
@@ -157,7 +157,7 @@ class HavocRover(BaseChar):
             self.click_liberation(send_click=True)
             self.wind_routine_wait_down(check_forte_full=False)
             self.sleep(0.03)
-        if self.is_mouse_forte_full():
+        if self.is_forte_full():
             self.send_resonance_key()
             return
         self.click_echo(time_out=0)
@@ -171,5 +171,5 @@ class HavocRover(BaseChar):
             self.click_resonance(send_click=False)
         if self.click_liberation(send_click=True):
             self.sleep(0.03)
-        if self.is_mouse_forte_full():
+        if self.is_forte_full():
             self.send_resonance_key()

--- a/src/char/Phrolova.py
+++ b/src/char/Phrolova.py
@@ -14,18 +14,23 @@ class Phrolova(BaseChar):
     def do_perform(self):
         self.last_liberation = -1
         if self.has_intro:
-            self.continues_normal_attack(0.5)
+            if self.check_outro() in {'char_cantarella'}:
+                self.do_perform_outro()
+                return self.switch_next_char()
+            self.continues_normal_attack(0.8)
         if self.flying():
             self.wait_down()
         if self.click_liberation():
             return self.switch_next_char()
-        elif self.heavy_and_liber():           
+        if self.heavy_and_liber():           
             return self.switch_next_char()
         self.continues_normal_attack(3, click_resonance_if_ready_and_return=True)
         self.click_echo()
         self.switch_next_char()
 
     def do_get_switch_priority(self, current_char: BaseChar, has_intro=False, target_low_con=False):
+        if self.time_elapsed_accounting_for_freeze(self.last_liberation) > 8 and has_intro and current_char.char_name in {'char_cantarella'}:
+            return Priority.MAX
         if self.time_elapsed_accounting_for_freeze(self.last_liberation) < 24:
             return Priority.MIN
         return Priority.FAST_SWITCH
@@ -38,3 +43,21 @@ class Phrolova(BaseChar):
             self.logger.debug('Phrolova heavy_click_forte')
             self.task.wait_until(self.click_liberation, time_out=3)
             return True
+            
+    def do_perform_outro(self):
+        if self.flying():
+            self.wait_down()
+        if self.click_liberation():
+            return
+        self.continues_normal_attack(0.5)
+        while self.time_elapsed_accounting_for_freeze(self.last_perform) < 16:
+            if self.click_liberation():
+                return
+            if self.heavy_and_liber():           
+                return self.switch_next_char()
+            self.click_echo()  
+            if self.resonance_available():
+                self.click_resonance()
+            self.task.click()
+            self.check_combat()
+            self.task.next_frame()

--- a/src/char/Phrolova.py
+++ b/src/char/Phrolova.py
@@ -19,8 +19,7 @@ class Phrolova(BaseChar):
             self.wait_down()
         if self.click_liberation():
             return self.switch_next_char()
-        elif self.heavy_click_forte(check_fun=self.is_mouse_forte_full):
-            self.logger.debug('Phrolova heavy_click_forte')
+        elif self.heavy_and_liber():           
             return self.switch_next_char()
         self.continues_normal_attack(3, click_resonance_if_ready_and_return=True)
         self.click_echo()
@@ -30,7 +29,12 @@ class Phrolova(BaseChar):
         if self.time_elapsed_accounting_for_freeze(self.last_liberation) < 24:
             return Priority.MIN
         return Priority.FAST_SWITCH
-        # return super().do_get_switch_priority(current_char, has_intro)
 
     def resonance_available(self, current=None, check_ready=False, check_cd=False):
         return not (self.flying() or self.has_cd('resonance'))
+
+    def heavy_and_liber(self):
+        if self.heavy_click_forte(check_fun=self.is_mouse_forte_full):
+            self.logger.debug('Phrolova heavy_click_forte')
+            self.task.wait_until(self.click_liberation, time_out=3)
+            return True

--- a/src/char/ShoreKeeper.py
+++ b/src/char/ShoreKeeper.py
@@ -14,5 +14,5 @@ class ShoreKeeper(Healer):
         self.liberation_available() and self.wait_down()
         self.click_liberation()
         self.click_echo(time_out=0)
-        self.heavy_click_forte()
+        self.heavy_click_forte(check_fun = self.is_mouse_forte_full)
         self.switch_next_char()

--- a/src/char/ShoreKeeper.py
+++ b/src/char/ShoreKeeper.py
@@ -1,7 +1,14 @@
+import time
+
 from src.char.Healer import Healer
 
 
 class ShoreKeeper(Healer):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.outrotime = -1
+        self.dodge_count = 0
+
     def count_liberation_priority(self):
         return 2
     
@@ -16,3 +23,25 @@ class ShoreKeeper(Healer):
         self.click_echo(time_out=0)
         self.heavy_click_forte(check_fun = self.is_mouse_forte_full)
         self.switch_next_char()
+
+    def switch_next_char(self, *args):
+        if self.is_con_full():
+            self.outrotime = time.time()
+            self.dodge_count = 5
+        return super().switch_next_char(*args)
+
+    def auto_dodge(self, condition):
+        clicked = False
+        if self.time_elapsed_accounting_for_freeze(self.outrotime) < 30 and self.dodge_count > 0:
+            start = time.time()
+            while time.time() - start < 1.5:
+                if not condition():
+                    break
+                self.continues_right_click(0.05)
+                self.sleep(0.05)
+                clicked = True
+                self.task.next_frame()
+        if clicked:
+            self.dodge_count -= 1
+            self.logger.info('ShoreKeepers auto dodge success!')
+        return clicked


### PR DESCRIPTION
长离
回路重击结束条件也改为is_mouse_forte_full
主角
光主和风主回路不会重击，改回了forte_full条件
回路为重击的暗住补上了is_mouse_forte_full
土豆&夏空
支持is_mouse_forte_full
守岸人
1.支持is_mouse_forte_full
2.加了个延奏中自动闪避受身的接口
fll
1.重击后不切人直接开r
2.坎延奏中改打长轴
3.平a时检测被肘，处于守岸人延奏中时闪避受身
坎
1.支持is_mouse_forte_full
2.修改行为逻辑为打短轴以解决fast_switch中不重击的问题，洛可可/散华延奏中时照旧打长轴
3.坎强化状态中e2的取消级低于平a，因此改用长按进行平a，以确保e能正常释放