### PR TITLE
修复转圈奔跑不按F

### DIFF
--- a/src/task/BaseCombatTask.py
+++ b/src/task/BaseCombatTask.py
@@ -259,7 +259,7 @@ class BaseCombatTask(CombatCheck):
             bool: 如果成功拾取到声骸则返回 True, 否则 False。
         """
         directions = ['w', 'a', 's', 'd']
-        step = 1.2
+        step = 0.8
         duration = 0.8
         total_index = 0
         for count in range(circle_count):
@@ -269,11 +269,10 @@ class BaseCombatTask(CombatCheck):
                     if not (count == circle_count - 1 and direction == directions[-1]):
                         duration += step
 
-                picked = self.send_key_and_wait_f(direction, False, time_out=duration, running=True,
-                                                  target_text=self.absorb_echo_text())
-                if picked:
-                    self.mouse_up(key="right")
-                    return True
+                if self.send_key_and_wait_f(direction, False, time_out=duration, running=True,
+                                                  target_text=self.absorb_echo_text()):
+                    if self.pick_f():
+                        return True
                 total_index += 1
 
     def switch_next_char(self, current_char, post_action=None, free_intro=False, target_low_con=False):

--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -340,7 +340,6 @@ class BaseWWTask(BaseTask):
             if self.send_key_and_wait_f(direction, raise_if_not_found, time_out, target_text=target_text,
                                         running=False, check_combat=check_combat):
                 logger.info('walk forward found f')
-                self.sleep(0.5)
                 return True
             return False
         else:
@@ -593,7 +592,7 @@ class BaseWWTask(BaseTask):
         if self.walk_until_f(time_out=time_out, backward_time=backward_time, target_text=self.absorb_echo_text(),
                              raise_if_not_found=False, check_combat=True):  # find and pick echo
             logger.debug(f'farm echo found echo move forward walk_until_f to find echo')
-            return self.pick_echo()
+            return self.pick_f()
 
     def incr_drop(self, dropped):
         if dropped:

--- a/src/task/DailyTask.py
+++ b/src/task/DailyTask.py
@@ -60,9 +60,9 @@ class DailyTask(WWOneTimeTask, BaseCombatTask):
         self.send_key_up('alt')
         self.wait_ocr(0.2, 0.13, 0.32, 0.22, match=re.compile(r'\d+'), settle_time=1, raise_if_not_found=True, log=True)
         self.click(0.04, 0.3, after_sleep=1)
-        self.click(0.68, 0.91, after_sleep=2)
-        self.click(0.04, 0.17, after_sleep=2)
+        self.click(0.68, 0.91, after_sleep=3)
         self.click(0.04, 0.17, after_sleep=1)
+        self.click(0.68, 0.91, after_sleep=1)
         self.click(0.68, 0.91, after_sleep=1)
         self.ensure_main()
 


### PR DESCRIPTION
1.修复转圈奔跑不按F
2.优化捡声骸效率
现有的这3个捡声骸方案在芬莱克那似乎都不好使，他的判定范围太小了