### PR TITLE
fix teleport in forgery

### DIFF
--- a/src/task/ForgeryTask.py
+++ b/src/task/ForgeryTask.py
@@ -73,9 +73,9 @@ class ForgeryTask(DomainTask):
         self.sleep(max(5, self.teleport_timeout / 10))
         self.walk_until_f(time_out=2)
         self.pick_f()
-        self.wait_click_feature('gray_button_challenge', relative_x=4, raise_if_not_found=True,
-                                click_after_delay=1, threshold=0.6, after_sleep=1, time_out=20)
-        self.click_relative(0.93, 0.90, after_sleep=1)
+        self.wait_click_feature('gray_button_challenge', relative_x=4, raise_if_not_found=True, click_after_delay=1, threshold=0.6, after_sleep=1, time_out=20) # solo challenge
+        self.click_relative(0.62, 0.62, after_sleep=1) # click confirm of not enough stamina dialog (may appear)
+        self.click_relative(0.93, 0.90, after_sleep=1) # start challenge
         self.wait_in_team_and_world(time_out=self.teleport_timeout)
 
     def get_material_mat(self):

--- a/src/task/ForgeryTask.py
+++ b/src/task/ForgeryTask.py
@@ -70,7 +70,7 @@ class ForgeryTask(DomainTask):
             self.get_material_mat()
         self.wait_click_travel()
         self.wait_in_team_and_world(time_out=self.teleport_timeout)
-        self.sleep(1)
+        self.sleep(max(5, self.teleport_timeout / 10))
         self.walk_until_f(time_out=2)
         self.pick_f()
         self.wait_click_feature('gray_button_challenge', relative_x=4, raise_if_not_found=True,

--- a/src/task/SimulationTask.py
+++ b/src/task/SimulationTask.py
@@ -54,7 +54,8 @@ class SimulationTask(DomainTask):
             index = 1
         else:  # selection == 'Shell Credit'
             index = 2
-        self.click_relative(0.22, 0.17 + index * 0.08, after_sleep=1)
-        self.click_relative(0.93, 0.90, after_sleep=1)
-        self.click_relative(0.93, 0.90, after_sleep=1)
+        self.click_relative(0.22, 0.17 + index * 0.08, after_sleep=1) # choose material
+        self.wait_click_feature('gray_button_challenge', relative_x=4, raise_if_not_found=True, click_after_delay=1, threshold=0.6, after_sleep=1, time_out=20) # solo challenge
+        self.click_relative(0.62, 0.62, after_sleep=1) # click confirm of not enough stamina dialog (may appear)
+        self.click_relative(0.93, 0.90, after_sleep=1) # start challenge
         self.wait_in_team_and_world(time_out=self.teleport_timeout)

--- a/src/task/SimulationTask.py
+++ b/src/task/SimulationTask.py
@@ -45,8 +45,8 @@ class SimulationTask(DomainTask):
         self.click_relative(0.88, 494 / 1440, after_sleep=1)
         self.wait_click_travel()
         self.wait_in_team_and_world(time_out=self.teleport_timeout)
-        self.sleep(1)
-        self.walk_until_f(time_out=1)
+        self.sleep(max(5, self.teleport_timeout / 10))
+        self.walk_until_f(time_out=2)
         self.pick_f()
         if selection == 'Resonator EXP':
             index = 0


### PR DESCRIPTION
1. 将加载超时加回来，避免下图错误（入口尚未加载完成）导致 `wall_until_f` 报错。

<img width="1920" height="1080" alt="11-29-54 768_20250728_112953_246024 daily_task_2 farm_forgery attempt 1_original" src="https://github.com/user-attachments/assets/2b201849-a87d-47a3-a640-36794a71a8e9" />

2. 适配 一条龙/凝素领域 体力不足对话框 弹出的情形（当前体力不足但是全部体力足够）。

![20250728-125553](https://github.com/user-attachments/assets/c145ff67-3f83-4008-8ead-09d10834c9c6)

