### PR TITLE
优化刷梦魇巢穴

### DIFF
--- a/src/task/DailyTask.py
+++ b/src/task/DailyTask.py
@@ -50,7 +50,7 @@ class DailyTask(WWOneTimeTask, BaseCombatTask):
                     self.sleep(2)
                     self.get_task_by_class(ForgeryTask).purification_material()
                 self.sleep(4)
-            if self.config.get('Which to Farm', self.support_tasks[0]) == self.support_tasks[0]:
+            if self.config.get('Auto Farm all Nightmare Nest'):
                 try:
                     self.get_task_by_class(NightmareNestTask).run()
                 except Exception as e:


### PR DESCRIPTION
1.修改了日常一条龙的条件错误
2.梦魇巢穴的声骸识别改为”设置为晚上“+循环执行”传送至中场并寻找声骸“直到4次或者声骸全部捡完