### PR TITLE
Zhezhi, Zani, Cartethyia auto combat enhancement

### DIFF
--- a/src/char/Zani.py
+++ b/src/char/Zani.py
@@ -32,6 +32,7 @@ class Zani(BaseChar):
         self.last_liber2 = -1
         self.dodge_time = -1
         self.attack_breakthrough_time = -1
+        self.no_post_n3_pause = True
 
     def reset_state(self):
         self.char_phoebe = None
@@ -143,7 +144,7 @@ class Zani(BaseChar):
         if self.is_forte_full():
             return State.FORTE_FULL
         self.logger.info(f'basic attack - breakthrough')
-        if self.chair_time == -1:
+        if self.chair_time == -1 or getattr(self, "no_post_n3_pause", False):
             if (result := self.basic_attack_breakthrough()) != State.DONE:
                 return result
         else:
@@ -306,6 +307,10 @@ class Zani(BaseChar):
                 return result
         elif result == State.FORTE_FULL:
             return State.FORTE_FULL
+        # ✅ 여기서 ‘3타 히트보정 대기’를 거의 0으로 줄임
+        if getattr(self, "no_post_n3_pause", False):
+            # 거의 즉시 다음 입력으로 넘어가도록 0~0.05초 사이로 클램프
+            wait_chair = 0.02
         if (result := self.wait_forte_full(wait_chair)) != State.DONE:
             return result
         self.continues_normal_attack(0.1)
@@ -527,6 +532,7 @@ class Zani(BaseChar):
             self.blazes = -1
             self.state = 0
         return self.state
+    
 
 
 zani_light_color = {


### PR DESCRIPTION
I've modified the auto combat script for the following three characters. I'd appreciate it if you could check it out.

Modified:
Zhezi: After curcuit, the part where the e-key is consecutively pressed is modified to hold the e+jump+ regular attack key for 0.4 seconds (which is faster than what we used before). However, this requires accurate input, so it may require detailed adjustments. By default, 0.35 seconds is the minimum time required for heavy attacks in wutherring waves. So, I set it to 0.4 seconds.)

If Zani:R is not in use, I've been waiting for multiple hit attacks since normal attack 3 and trying to fix where I don't use the next attack. 

Cartethyia: When I'm in kid mode and the navigation tool isn't in control, I tried to fix the part where the character is inaction for 2.5 seconds or so.