### PR TITLE
修复了刷异构武装时，复活后可能无法正常返回的问题。（需要在选项中选择异构武装）

### DIFF
--- a/src/task/FarmEchoTask.py
+++ b/src/task/FarmEchoTask.py
@@ -283,7 +283,6 @@ class FarmEchoTask(WWOneTimeTask, BaseCombatTask):
             self.run_until(lambda: self.in_combat() or self.find_treasure_icon(), 'w', time_out=12, running=True)
 
     def teleport_to_nearest_boss(self):
-        print(f"===============\n\n\n\n\n\n{self.aim_boss}\n\n\n\n\n\n=================")
         if self.aim_boss is not None:
             self.log_info(f'teleport_to_nearest_boss {self.aim_boss}')
             self.ensure_main(time_out=180)


### PR DESCRIPTION
通过在manage_boss_parameters方法中复用self.aim_boss的接口，实现在复活后通过搜索返回异构武装boss战的逻辑。