### PR TITLE
调整日常一条龙中梦魇巢穴的运行顺序

### DIFF
--- a/src/task/DailyTask.py
+++ b/src/task/DailyTask.py
@@ -39,6 +39,14 @@ class DailyTask(WWOneTimeTask, BaseCombatTask):
     def run(self):
         WWOneTimeTask.run(self)
         self.ensure_main(time_out=180)
+        # nightmare
+        if self.config.get('Auto Farm all Nightmare Nest'):
+            try:
+                self.run_task_by_class(NightmareNestTask)
+            except Exception as e:
+                self.log_error("NightmareNestTask Failed", e)
+                self.ensure_main(time_out=180)
+        # daily task (with 60 points for 180 stamina consuming)
         used_stamina, completed = self.open_daily()
         self.send_key('esc', after_sleep=1)
         if not completed:
@@ -52,12 +60,6 @@ class DailyTask(WWOneTimeTask, BaseCombatTask):
                     self.sleep(2)
                     self.get_task_by_class(ForgeryTask).purification_material()
                 self.sleep(4)
-            if self.config.get('Auto Farm all Nightmare Nest'):
-                try:
-                    self.run_task_by_class(NightmareNestTask)
-                except Exception as e:
-                    self.log_error("NightmareNestTask Failed", e)
-                    self.ensure_main(time_out=180)
             self.claim_daily()
 
         self.claim_mail()


### PR DESCRIPTION
将梦魇巢穴任务调整为一条龙的首个任务，执行之前将不再进行体力判断。

- 这样可以确保用户勾选则必定执行。
- 梦魇巢穴任务执行完毕后，玩家所在位置第二天会直接刷出怪物，将体力任务放在梦魇巢穴之后有利于避免这种情况。
