### PR TITLE
更新use_stamina方法

### DIFF
--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -408,26 +408,20 @@ class BaseWWTask(BaseTask):
 
     def use_stamina(self, once, must_use=0):
         self.sleep(1)
-        double = self.ocr(0.55, 0.56, 0.75, 0.69, match=[re.compile(str(once * 2))])
         current, back_up, total = self.get_stamina()
         y = 0.62
-        if not double:  # 找不到双倍数字, 说明有UP, 点击右边
+        if current >= once * 2:
+            used = once * 2
             x = 0.67
-            logger.info("找不到双倍数字, 说明有UP, 点击右边")
-            used = once
+            logger.info(f"当前体力大于等于双倍, {current} >= {once * 2}")
+        elif must_use > once and total >= once * 2:
+            used = once * 2
+            x = 0.67
+            logger.info(f"当前加备用大于日常剩余所需, 使用双倍, {must_use} >= {once} and {total} >= {once * 2}")
         else:
-            if current >= once * 2:
-                used = once * 2
-                x = 0.67
-                logger.info(f"当前体力大于等于双倍, {current} >= {once * 2}")
-            elif must_use > once and total >= once * 2:
-                used = once * 2
-                x = 0.67
-                logger.info(f"当前加备用大于日常剩余所需, 使用双倍, {must_use} >= {once} and {total} >= {once * 2}")
-            else:
-                logger.info(f"使用单倍体力")
-                used = once
-                x = 0.32
+            used = once
+            x = 0.32
+            logger.info(f"使用单倍体力")
         self.click(x, y, after_sleep=0.5)
         if self.wait_feature('gem_add_stamina', horizontal_variance=0.4, vertical_variance=0.05,
                              time_out=1):  # 看是否需要使用备用体力


### PR DESCRIPTION
What changed: 更新了BaseWWTask中use_stamina方法

Why: 3.0更新后，双倍掉落活动可与普通双倍叠加使用。在双倍活动时不会再弹出特别的领取奖励对话框，因而无需判断是否有双倍活动。

Test: 实际运行了几次Dungeon Task，验证了无论是否有双倍掉落活动均能正常领取奖励。