### PR TITLE
添加f_break释放依据，修改若干角色f的释放时机

### DIFF
--- a/src/char/BaseChar.py
+++ b/src/char/BaseChar.py
@@ -86,6 +86,7 @@ class BaseChar:
         self.last_outro_time = -1
         self.confidence = confidence
         self.logger = Logger.get_logger(self.name)
+        self.check_f_on_switch = True
 
     def skip_combat_check(self):
         """是否在某些操作中跳过战斗状态检查。
@@ -886,6 +887,17 @@ class BaseChar:
     def has_long_action2(self):
         """是否有长动作条"""
         return self.task.find_one(self.task.get_target_names()[0], box='target_box_long2', threshold=0.6)
+        
+    def f_break(self, check_f_on_switch=False):
+        """使用F进行击破
+           若self.check_f_on_switch为False则不在切走前自动按F,须在逻辑中手动添加。
+           另外击破动画带全局时停且目前无法识别动画,可能会出现计时问题
+        """
+        if check_f_on_switch and not self.check_f_on_switch:
+            return 
+        if self.task.find_one('f_break', box=self.task.box_of_screen(0.2, 0.2, 0.75, 0.8)):
+            self.logger.debug('boss is broken, use f')
+            self.task.send_key('f', after_sleep=0.1)
 
 forte_white_color = {  # 用于检测共鸣回路UI元素可用状态的白色颜色范围。
     'r': (244, 255),  # Red range

--- a/src/char/Brant.py
+++ b/src/char/Brant.py
@@ -9,6 +9,7 @@ class Brant(BaseChar):
         self.perform_anchor = 0
         self.attribute = 0
         self.char_lupa = None
+        self.check_f_on_switch = False
 
     def reset_state(self):
         super().reset_state()
@@ -21,6 +22,7 @@ class Brant(BaseChar):
             self.continues_normal_attack(1.3)
             if self.check_outro() in {'char_lupa'} and self.perform_in_outro():
                 return self.switch_next_char()
+        self.f_break()
         if self.is_forte_full() and self.resonance_available():
             self.resonance_forte_full()
             self.last_liberation = -1

--- a/src/char/Changli.py
+++ b/src/char/Changli.py
@@ -18,6 +18,7 @@ class Changli(BaseChar):
     def do_perform(self):
         outro = False
         forte = -1
+        self.check_f_on_switch = True
         if self.has_intro:
             self.continues_normal_attack(0.3)
             self.enhanced_normal = True
@@ -38,10 +39,12 @@ class Changli(BaseChar):
             if self.flying():
                 self.heavy_attack()
             self.heavy_click_forte(check_fun=self.is_mouse_forte_full)
+            self.check_f_on_switch = False
             self.check_combat()
             return self.switch_next_char()
         if not (forte >= 3 and self.resonance_available()) and self.liberation_available():
             if self.liberation_and_heavy():
+                self.check_f_on_switch = False
                 return self.switch_next_char()
         if self.flick_resonance(send_click=False):
             self.enhanced_normal = True

--- a/src/char/Lupa.py
+++ b/src/char/Lupa.py
@@ -10,6 +10,7 @@ class Lupa(BaseChar):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.wolf = False
+        self.check_f_on_switch = False
 
     def reset_state(self):
         super().reset_state()
@@ -47,6 +48,7 @@ class Lupa(BaseChar):
                 self.wait_down()
             else:
                 return self.switch_next_char()
+        self.f_break()
         if (in_outro or not self.need_fast_perform()) and self.click_liberation():
             self.continues_normal_attack(0.3)
             if in_outro:

--- a/src/char/Zani.py
+++ b/src/char/Zani.py
@@ -32,6 +32,7 @@ class Zani(BaseChar):
         self.last_liber2 = -1
         self.dodge_time = -1
         self.attack_breakthrough_time = -1
+        self.check_f_on_switch = False
 
     def reset_state(self):
         self.char_phoebe = None
@@ -62,6 +63,7 @@ class Zani(BaseChar):
             return self.switch_next_char()
         else:
             self.state = 0
+            self.f_break()
 
         if self.echo_available():
             self.click_echo(time_out=0)

--- a/src/task/BaseCombatTask.py
+++ b/src/task/BaseCombatTask.py
@@ -282,10 +282,6 @@ class BaseCombatTask(CombatCheck):
                         return True
                 total_index += 1
 
-    def f_break(self):
-        if self.find_one('f_break', box=self.box_of_screen(0.2, 0.2, 0.75, 0.8)):
-            self.log_debug('boss is broken, use f')
-            self.send_key('f', after_sleep=0.1)
 
     def switch_next_char(self, current_char, post_action=None, free_intro=False, target_low_con=False):
         """切换到下一个最优角色。
@@ -344,7 +340,7 @@ class BaseCombatTask(CombatCheck):
         start = time.time()
         while True:
             now = time.time()
-            self.f_break()
+            current_char.f_break(check_f_on_switch=True)
             _, current_index, _ = self.in_team()
             if current_index == current_char.index:
                 self.update_lib_portrait_icon()


### PR DESCRIPTION
另，f击破动画中全局时停，但目前暂时无法检测该动画时长，可能会导致角色的特殊状态时间出现误判
因此角色尽量不在特殊状态中使用f击破
船长:修改为进场时
露帕:修改为开r前
长离:切人前重击则不释放
赞尼:开大时不释放
