### PR TITLE
修复日常一条龙在活跃度已满时无法领取100活跃奖励

### DIFF
--- a/src/task/DailyTask.py
+++ b/src/task/DailyTask.py
@@ -73,23 +73,22 @@ class DailyTask(WWOneTimeTask, BaseCombatTask):
             except Exception as e:
                 self.log_error("NightmareNestTask Failed", e)
                 self.ensure_main(time_out=180)
-        used_stamina, completed = self.open_daily()
-
-        self.send_key('esc', after_sleep=1)
-        if not completed:
-            if used_stamina < 180:
-                target = self.config.get('Which to Farm', self.support_tasks[0])
-                if target == self.support_tasks[0]:
-                    self.get_task_by_class(TacetTask).farm_tacet(daily=True, used_stamina=used_stamina,
+        used_stamina, daily_reward_ready = self.open_daily()
+        if not daily_reward_ready and used_stamina < 180:
+            self.send_key('esc', after_sleep=1)
+            target = self.config.get('Which to Farm', self.support_tasks[0])
+            if target == self.support_tasks[0]:
+                self.get_task_by_class(TacetTask).farm_tacet(daily=True, used_stamina=used_stamina,
+                                                             config=self.config)
+            elif target == self.support_tasks[1]:
+                self.get_task_by_class(ForgeryTask).farm_forgery(daily=True, used_stamina=used_stamina,
                                                                  config=self.config)
-                elif target == self.support_tasks[1]:
-                    self.get_task_by_class(ForgeryTask).farm_forgery(daily=True, used_stamina=used_stamina,
-                                                                     config=self.config)
-                else:
-                    self.get_task_by_class(SimulationTask).farm_simulation(daily=True, used_stamina=used_stamina,
-                                                                           config=self.config)
-                self.sleep(4)
-            self.claim_daily()
+            else:
+                self.get_task_by_class(SimulationTask).farm_simulation(daily=True, used_stamina=used_stamina,
+                                                                       config=self.config)
+            self.sleep(4)
+
+        self.claim_daily()
 
         self.claim_mail()
         self.sleep(1)
@@ -157,19 +156,44 @@ class DailyTask(WWOneTimeTask, BaseCombatTask):
 
     def claim_daily(self):
         self.info_set('current task', 'claim daily')
-        self.ensure_main(time_out=5)
-        self.open_daily()
-
-        self.click(0.87, 0.17, after_sleep=0.5)
-        self.sleep(1)
-
         total_points = self.get_total_daily_points()
+        if total_points < 100:
+            self.ensure_main(time_out=5)
+            self.open_daily()
+            self.log_info('claim pending daily quest rewards before claiming daily chest')
+            self.click(0.87, 0.17, after_sleep=0.5)
+            self.sleep(1)
+            total_points = self.get_total_daily_points()
+
         self.info_set('daily points', total_points)
         if total_points < 100:
             raise Exception("Can't complete daily task, may need to increase stamina manually!")
 
-        self.click(0.89, 0.85, after_sleep=1)
+        self.click_daily_reward_box(100)
         self.ensure_main(time_out=10)
+
+    def click_daily_reward_box(self, reward_points):
+        reward_boxes = self.ocr(
+            0.72, 0.78, 0.98, 0.98,
+            match=re.compile(rf'^{reward_points}$')
+        )
+        if reward_boxes:
+            reward_box = max(reward_boxes, key=lambda box: box.x)
+            click_box = reward_box.copy(
+                x_offset=int(-reward_box.width * 0.8),
+                y_offset=int(-reward_box.height * 3.0),
+                width_offset=int(reward_box.width * 1.6),
+                height_offset=int(reward_box.height * 2.2),
+                name=f'daily_reward_{reward_points}'
+            )
+            self.log_info(f'claim daily reward {reward_points} via OCR {reward_box}')
+            self.click(click_box, after_sleep=1)
+            return True
+
+        # Fall back to a more right-shifted point than the previous fixed coordinate.
+        self.log_info(f'claim daily reward {reward_points} via fallback coordinate')
+        self.click(0.94, 0.85, after_sleep=1)
+        return False
 
     def claim_mail(self):
         self.info_set('current task', 'claim mail')

--- a/tests/TestDailyTaskLogic.py
+++ b/tests/TestDailyTaskLogic.py
@@ -1,0 +1,88 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ok import Box
+from src.task.DailyTask import DailyTask
+
+
+class TestDailyTaskLogic(unittest.TestCase):
+
+    def make_task(self):
+        task = DailyTask.__new__(DailyTask)
+        task.config = {
+            'Auto Farm all Nightmare Nest': False,
+            'Farm Nightmare Nest for Daily Echo': False,
+        }
+        task.support_tasks = ["Tacet Suppression", "Forgery Challenge", "Simulation Challenge"]
+        task.ensure_main = MagicMock()
+        task.go_to_tower = MagicMock()
+        task.open_daily = MagicMock()
+        task.send_key = MagicMock()
+        task.get_task_by_class = MagicMock()
+        task.claim_daily = MagicMock()
+        task.claim_mail = MagicMock()
+        task.claim_battle_pass = MagicMock()
+        task.sleep = MagicMock()
+        task.info_set = MagicMock()
+        task.log_info = MagicMock()
+        task.log_debug = MagicMock()
+        task.log_error = MagicMock()
+        task.run_task_by_class = MagicMock()
+        return task
+
+    @patch('src.task.DailyTask.WWOneTimeTask.run', autospec=True)
+    def test_claims_daily_reward_when_reward_is_already_ready(self, mock_base_run):
+        task = self.make_task()
+        task.open_daily.return_value = (180, True)
+
+        task.run()
+
+        mock_base_run.assert_called_once_with(task)
+        task.claim_daily.assert_called_once()
+        task.claim_mail.assert_called_once()
+        task.claim_battle_pass.assert_called_once()
+        task.get_task_by_class.assert_not_called()
+        task.send_key.assert_not_called()
+
+    def test_click_daily_reward_box_prefers_ocr_located_reward(self):
+        task = self.make_task()
+        task.ocr = MagicMock(return_value=[Box(2300, 1280, 70, 30, name='100')])
+        task.click = MagicMock()
+
+        result = task.click_daily_reward_box(100)
+
+        self.assertTrue(result)
+        task.click.assert_called_once()
+        click_box = task.click.call_args.args[0]
+        self.assertLess(click_box.y, 1280)
+        self.assertGreater(click_box.height, 30)
+
+    def test_click_daily_reward_box_falls_back_when_ocr_not_found(self):
+        task = self.make_task()
+        task.ocr = MagicMock(return_value=[])
+        task.click = MagicMock()
+
+        result = task.click_daily_reward_box(100)
+
+        self.assertFalse(result)
+        task.click.assert_called_once_with(0.94, 0.85, after_sleep=1)
+
+    def test_claim_daily_skips_top_claim_click_when_points_already_ready(self):
+        task = self.make_task()
+        task.claim_daily = DailyTask.claim_daily.__get__(task, DailyTask)
+        task.open_daily = MagicMock()
+        task.get_total_daily_points = MagicMock(return_value=100)
+        task.click = MagicMock()
+        task.click_daily_reward_box = MagicMock()
+        task.ensure_main = MagicMock()
+
+        task.claim_daily()
+
+        task.click.assert_not_called()
+        task.ensure_main.assert_called_once_with(time_out=10)
+        task.open_daily.assert_not_called()
+        task.click_daily_reward_box.assert_called_once_with(100)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 变更说明
修复 DailyTask 在活跃度奖励已经可领取时，日常一条龙不会正确领取 100 活跃奖励的问题。

## 具体改动
- 在活跃度奖励已经可领取时，仍然继续执行日常奖励领取流程
- 如果第一次 `open_daily()` 已经识别到活跃度达到 100，则直接在当前日常页面领取奖励，不再回主界面再打开一次日常页
- 优先通过 OCR 定位底部 `100` 奖励箱并点击，保留一个兜底点击坐标
- 增加针对该场景的回归测试

## 验证情况
- 本地实际复现并验证了“活跃度已满时领取 100 奖励箱”的流程
- 运行通过：
  - `python -m unittest tests.TestDailyTaskLogic`