### PR TITLE
修正了当ocr失败时使用的备用点击坐标

### DIFF
--- a/src/task/DailyTask.py
+++ b/src/task/DailyTask.py
@@ -192,7 +192,7 @@ class DailyTask(WWOneTimeTask, BaseCombatTask):
 
         # Fall back to a more right-shifted point than the previous fixed coordinate.
         self.log_info(f'claim daily reward {reward_points} via fallback coordinate')
-        self.click(0.94, 0.85, after_sleep=1)
+        self.click(0.90, 0.85, after_sleep=1)
         return False
 
     def claim_mail(self):


### PR DESCRIPTION
当领取日常奖励时，如果ocr失败则会调用备用的坐标进行领取，但是我发现备用点击坐标不正确，修改后在我的本地中可以正确点击领取图标