### PR TITLE
拓宽了多账号任务中登录其他账号时的检测高度

### DIFF
--- a/src/task/MultiAccountDailyTask.py
+++ b/src/task/MultiAccountDailyTask.py
@@ -132,7 +132,7 @@ class MultiAccountDailyTask(WWOneTimeTask, BaseCombatTask):
 
     def _click_account_in_list(self, pattern):
         texts = self.ocr()
-        if boxes := self.find_boxes(texts, boundary=self.box_of_screen(0.3, 0.3, 0.65, 0.9), match=pattern):
+        if boxes := self.find_boxes(texts, boundary=self.box_of_screen(0.3, 0.0, 0.65, 1.0), match=pattern):
             self.click(boxes[0], after_sleep=0.5)
             return True
         return False


### PR DESCRIPTION
将原本的屏幕高度30%-65%拓展到全高度范围，可以支持账号数更多一些的情况。