### PR TITLE
refactor(ocr): 替换OCR工具箱以提升识别可靠性

### DIFF
--- a/config.py
+++ b/config.py
@@ -89,8 +89,9 @@ config = {
         'lib': 'onnxocr',
         'auto_simplify': True,
         'params': {
-            'use_openvino': True,
-            'use_npu': True,
+            # Prefer CPU path for stable full-screen OCR coverage.
+            'use_openvino': False,
+            'use_npu': False,
         }
     },
     'my_app': ['src.globals', 'Globals'],

--- a/config.py
+++ b/config.py
@@ -89,9 +89,8 @@ config = {
         'lib': 'onnxocr',
         'auto_simplify': True,
         'params': {
-            # Prefer CPU path for stable full-screen OCR coverage.
-            'use_openvino': False,
-            'use_npu': False,
+            'use_openvino': True,
+            'use_npu': True,
         }
     },
     'my_app': ['src.globals', 'Globals'],

--- a/src/ocr_helper_tool/__init__.py
+++ b/src/ocr_helper_tool/__init__.py
@@ -1,0 +1,12 @@
+from .interfaces import Box, OCRText
+from .adapters import create_ocr_adapter
+from .core import OCRSession, COMMON_RESOLUTIONS
+
+__all__ = [
+    "Box",
+    "OCRText",
+    "create_ocr_adapter",
+    "OCRSession",
+    "COMMON_RESOLUTIONS",
+]
+

--- a/src/ocr_helper_tool/adapters.py
+++ b/src/ocr_helper_tool/adapters.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import importlib
+from typing import Dict, List, Optional, Tuple
+
+from PIL import Image
+
+from .interfaces import Box, OCRAdapter, OCRText
+
+
+def _to_text_items(
+    raw_items: List[Tuple[List[List[float]], str, float]],
+    offset_x: int,
+    offset_y: int,
+) -> List[OCRText]:
+    texts: List[OCRText] = []
+    for points, text_raw, score_raw in raw_items:
+        text = str(text_raw).strip()
+        if not text:
+            continue
+        score = float(score_raw)
+        xs = [int(p[0]) for p in points]
+        ys = [int(p[1]) for p in points]
+        x1 = min(xs) + offset_x
+        y1 = min(ys) + offset_y
+        x2 = max(xs) + offset_x
+        y2 = max(ys) + offset_y
+        box = Box(x1, y1, x2, y2)
+        texts.append(
+            OCRText(
+                text=text,
+                box=box,
+                confidence=max(0.0, min(1.0, score)),
+                font_size=max(8, box.height),
+            )
+        )
+    return texts
+
+
+class DummyOCRAdapter(OCRAdapter):
+    name = "Dummy"
+
+    def recognize(self, image_path: str, region: Optional[Box] = None) -> List[OCRText]:
+        if region is None:
+            region = Box(20, 20, 380, 84)
+        return [
+            OCRText(
+                text="[Dummy] OCR engine unavailable",
+                box=region.normalized(),
+                confidence=1.0,
+                font_size=14,
+            )
+        ]
+
+
+class TesseractOCRAdapter(OCRAdapter):
+    name = "Tesseract"
+
+    def __init__(self, tesseract_cmd: Optional[str] = None) -> None:
+        self.module = importlib.import_module("pytesseract")
+        if tesseract_cmd:
+            self.module.pytesseract.tesseract_cmd = tesseract_cmd
+
+    def recognize(self, image_path: str, region: Optional[Box] = None) -> List[OCRText]:
+        image = Image.open(image_path).convert("RGB")
+        ox, oy = 0, 0
+        if region is not None:
+            r = region.normalized()
+            image = image.crop((r.x1, r.y1, r.x2, r.y2))
+            ox, oy = r.x1, r.y1
+
+        data = self.module.image_to_data(image, output_type=self.module.Output.DICT)
+        out: List[OCRText] = []
+        for i, raw in enumerate(data["text"]):
+            txt = raw.strip()
+            if not txt:
+                continue
+            try:
+                conf = max(0.0, min(1.0, float(data["conf"][i]) / 100.0))
+            except Exception:
+                conf = 0.0
+            x, y = int(data["left"][i]) + ox, int(data["top"][i]) + oy
+            w, h = int(data["width"][i]), int(data["height"][i])
+            if w <= 0 or h <= 0:
+                continue
+            out.append(
+                OCRText(
+                    text=txt,
+                    box=Box(x, y, x + w, y + h),
+                    confidence=conf,
+                    font_size=max(8, h),
+                )
+            )
+        return out
+
+
+class RapidOCRAdapter(OCRAdapter):
+    name = "RapidOCR"
+
+    def __init__(self) -> None:
+        module = importlib.import_module("rapidocr_onnxruntime")
+        self.engine = getattr(module, "RapidOCR")()
+
+    def recognize(self, image_path: str, region: Optional[Box] = None) -> List[OCRText]:
+        ox, oy = 0, 0
+        if region is None:
+            result, _elapsed = self.engine(image_path)
+        else:
+            import numpy as np
+
+            image = Image.open(image_path).convert("RGB")
+            r = region.normalized()
+            image = image.crop((r.x1, r.y1, r.x2, r.y2))
+            ox, oy = r.x1, r.y1
+            result, _elapsed = self.engine(np.array(image))
+        if not result:
+            return []
+        parsed = [(item[0], item[1], item[2]) for item in result if len(item) >= 3]
+        return _to_text_items(parsed, ox, oy)
+
+
+class PaddleOCRAdapter(OCRAdapter):
+    name = "PaddleOCR"
+
+    def __init__(self) -> None:
+        module = importlib.import_module("paddleocr")
+        PaddleOCR = getattr(module, "PaddleOCR")
+        self.engine = PaddleOCR(use_angle_cls=True, lang="ch")
+
+    def recognize(self, image_path: str, region: Optional[Box] = None) -> List[OCRText]:
+        ox, oy = 0, 0
+        if region is None:
+            result = self.engine.ocr(image_path, cls=True)
+        else:
+            import numpy as np
+
+            image = Image.open(image_path).convert("RGB")
+            r = region.normalized()
+            image = image.crop((r.x1, r.y1, r.x2, r.y2))
+            ox, oy = r.x1, r.y1
+            result = self.engine.ocr(np.array(image), cls=True)
+        raw_items: List[Tuple[List[List[float]], str, float]] = []
+        if result and result[0]:
+            for line in result[0]:
+                pts = line[0]
+                txt = line[1][0]
+                score = line[1][1]
+                raw_items.append((pts, txt, score))
+        return _to_text_items(raw_items, ox, oy)
+
+
+def create_ocr_adapter(engine: str = "auto") -> Tuple[OCRAdapter, str, Dict[str, bool]]:
+    status: Dict[str, bool] = {"Tesseract": False, "RapidOCR": False, "PaddleOCR": False}
+    engines = [engine] if engine != "auto" else ["RapidOCR", "PaddleOCR", "Tesseract"]
+
+    for name in engines:
+        try:
+            if name == "RapidOCR":
+                adapter = RapidOCRAdapter()
+            elif name == "PaddleOCR":
+                adapter = PaddleOCRAdapter()
+            elif name == "Tesseract":
+                adapter = TesseractOCRAdapter()
+            else:
+                continue
+            status[name] = True
+            return adapter, name, status
+        except Exception:
+            status[name] = False
+            continue
+    return DummyOCRAdapter(), "Dummy", status
+

--- a/src/ocr_helper_tool/adapters.py
+++ b/src/ocr_helper_tool/adapters.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import importlib
 from typing import Dict, List, Optional, Tuple
 
+import numpy as np
 from PIL import Image
 
-from .interfaces import Box, OCRAdapter, OCRText
+from .interfaces import Box, ImageInput, OCRAdapter, OCRText
 
 
 def _to_text_items(
@@ -40,7 +41,7 @@ def _to_text_items(
 class DummyOCRAdapter(OCRAdapter):
     name = "Dummy"
 
-    def recognize(self, image_path: str, region: Optional[Box] = None) -> List[OCRText]:
+    def recognize(self, image: ImageInput, region: Optional[Box] = None) -> List[OCRText]:
         if region is None:
             region = Box(20, 20, 380, 84)
         return [
@@ -61,8 +62,8 @@ class TesseractOCRAdapter(OCRAdapter):
         if tesseract_cmd:
             self.module.pytesseract.tesseract_cmd = tesseract_cmd
 
-    def recognize(self, image_path: str, region: Optional[Box] = None) -> List[OCRText]:
-        image = Image.open(image_path).convert("RGB")
+    def recognize(self, image: ImageInput, region: Optional[Box] = None) -> List[OCRText]:
+        image = _to_pil_rgb(image)
         ox, oy = 0, 0
         if region is not None:
             r = region.normalized()
@@ -101,17 +102,16 @@ class RapidOCRAdapter(OCRAdapter):
         module = importlib.import_module("rapidocr_onnxruntime")
         self.engine = getattr(module, "RapidOCR")()
 
-    def recognize(self, image_path: str, region: Optional[Box] = None) -> List[OCRText]:
+    def recognize(self, image: ImageInput, region: Optional[Box] = None) -> List[OCRText]:
         ox, oy = 0, 0
-        if region is None:
-            result, _elapsed = self.engine(image_path)
+        if region is None and isinstance(image, str):
+            result, _elapsed = self.engine(image)
         else:
-            import numpy as np
-
-            image = Image.open(image_path).convert("RGB")
-            r = region.normalized()
-            image = image.crop((r.x1, r.y1, r.x2, r.y2))
-            ox, oy = r.x1, r.y1
+            image = _to_pil_rgb(image)
+            if region is not None:
+                r = region.normalized()
+                image = image.crop((r.x1, r.y1, r.x2, r.y2))
+                ox, oy = r.x1, r.y1
             result, _elapsed = self.engine(np.array(image))
         if not result:
             return []
@@ -127,17 +127,16 @@ class PaddleOCRAdapter(OCRAdapter):
         PaddleOCR = getattr(module, "PaddleOCR")
         self.engine = PaddleOCR(use_angle_cls=True, lang="ch")
 
-    def recognize(self, image_path: str, region: Optional[Box] = None) -> List[OCRText]:
+    def recognize(self, image: ImageInput, region: Optional[Box] = None) -> List[OCRText]:
         ox, oy = 0, 0
-        if region is None:
-            result = self.engine.ocr(image_path, cls=True)
+        if region is None and isinstance(image, str):
+            result = self.engine.ocr(image, cls=True)
         else:
-            import numpy as np
-
-            image = Image.open(image_path).convert("RGB")
-            r = region.normalized()
-            image = image.crop((r.x1, r.y1, r.x2, r.y2))
-            ox, oy = r.x1, r.y1
+            image = _to_pil_rgb(image)
+            if region is not None:
+                r = region.normalized()
+                image = image.crop((r.x1, r.y1, r.x2, r.y2))
+                ox, oy = r.x1, r.y1
             result = self.engine.ocr(np.array(image), cls=True)
         raw_items: List[Tuple[List[List[float]], str, float]] = []
         if result and result[0]:
@@ -147,6 +146,20 @@ class PaddleOCRAdapter(OCRAdapter):
                 score = line[1][1]
                 raw_items.append((pts, txt, score))
         return _to_text_items(raw_items, ox, oy)
+
+
+def _to_pil_rgb(image: ImageInput) -> Image.Image:
+    if isinstance(image, Image.Image):
+        return image.convert("RGB")
+    if isinstance(image, str):
+        return Image.open(image).convert("RGB")
+    if isinstance(image, np.ndarray):
+        if image.ndim == 2:
+            return Image.fromarray(image).convert("RGB")
+        if image.ndim == 3 and image.shape[2] >= 3:
+            rgb = image[:, :, :3][:, :, ::-1]
+            return Image.fromarray(rgb).convert("RGB")
+    raise TypeError(f"Unsupported OCR image input type: {type(image)}")
 
 
 def create_ocr_adapter(engine: str = "auto") -> Tuple[OCRAdapter, str, Dict[str, bool]]:

--- a/src/ocr_helper_tool/artifacts.py
+++ b/src/ocr_helper_tool/artifacts.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import List
+
+import cv2
+from PIL import Image, ImageDraw, ImageFont
+
+from .geometry import pixel_box_to_rel
+from .interfaces import OCRText
+
+
+def make_timestamp_image_path(folder: str, ext: str = ".png") -> str:
+    Path(folder).mkdir(parents=True, exist_ok=True)
+    ts = int(time.time() * 1000)
+    return str(Path(folder) / f"{ts}{ext}")
+
+
+def build_artifact_path(base_image_path: str, suffix: str) -> str:
+    p = Path(base_image_path)
+    ext = p.suffix if p.suffix else ".png"
+    return str(p.with_name(f"{p.stem}{suffix}{ext}"))
+
+
+def pick_cjk_font(size: int):
+    candidates = [
+        r"C:\Windows\Fonts\msyh.ttc",
+        r"C:\Windows\Fonts\msyhbd.ttc",
+        r"C:\Windows\Fonts\simhei.ttf",
+        r"C:\Windows\Fonts\simsun.ttc",
+    ]
+    for path in candidates:
+        if os.path.exists(path):
+            try:
+                return ImageFont.truetype(path, size=size)
+            except Exception:
+                pass
+    return ImageFont.load_default()
+
+
+def write_raw_frame(frame_bgr, output_path: str) -> str:
+    cv2.imwrite(output_path, frame_bgr)
+    return output_path
+
+
+def write_annotated_image(image_path: str, results: List[OCRText]) -> str:
+    img = Image.open(image_path).convert("RGB")
+    draw = ImageDraw.Draw(img)
+    font = pick_cjk_font(16)
+    for item in results:
+        b = item.box.normalized()
+        draw.rectangle((b.x1, b.y1, b.x2, b.y2), outline=(0, 80, 255), width=2)
+        label = f"{item.text} | {item.confidence:.2f}"
+        tx, ty = b.x1 + 2, max(2, b.y1 - 20)
+        draw.rectangle((tx - 1, ty - 1, tx + len(label) * 9, ty + 18), fill=(20, 20, 20))
+        draw.text((tx, ty), label, fill=(255, 255, 0), font=font)
+    out = build_artifact_path(image_path, "_annotated")
+    img.save(out)
+    return out
+
+
+def write_results_json(image_path: str, results: List[OCRText], frame_w: int, frame_h: int, engine: str) -> str:
+    payload = {
+        "engine": engine,
+        "frame_size": {"width": frame_w, "height": frame_h},
+        "count": len(results),
+        "items": [],
+    }
+    for item in results:
+        b = item.box.normalized()
+        rel = pixel_box_to_rel(b, frame_w, frame_h).normalized()
+        payload["items"].append(
+            {
+                "text": item.text,
+                "confidence": round(float(item.confidence), 6),
+                "pixel_box": {"x1": b.x1, "y1": b.y1, "x2": b.x2, "y2": b.y2},
+                "relative_box": {
+                    "x1": round(rel.x1, 6),
+                    "y1": round(rel.y1, 6),
+                    "x2": round(rel.x2, 6),
+                    "y2": round(rel.y2, 6),
+                },
+            }
+        )
+    out = str(Path(image_path).with_name(f"{Path(image_path).stem}_results.json"))
+    with open(out, "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+    return out
+

--- a/src/ocr_helper_tool/artifacts.py
+++ b/src/ocr_helper_tool/artifacts.py
@@ -50,12 +50,7 @@ def write_raw_frame(frame_bgr, output_path: str) -> str:
     return output_path
 
 
-def write_annotated_frame(frame_bgr, base_path: str, results: List[OCRText]) -> str:
-    # base_path is used for naming only; no raw image is persisted.
-    rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
-    img = Image.fromarray(rgb).convert("RGB")
-    draw = ImageDraw.Draw(img)
-    font = pick_cjk_font(16)
+def _draw_ocr_overlays(draw: ImageDraw.ImageDraw, results: List[OCRText], font) -> None:
     for item in results:
         b = item.box.normalized()
         draw.rectangle((b.x1, b.y1, b.x2, b.y2), outline=(0, 80, 255), width=2)
@@ -63,6 +58,15 @@ def write_annotated_frame(frame_bgr, base_path: str, results: List[OCRText]) -> 
         tx, ty = b.x1 + 2, max(2, b.y1 - 20)
         draw.rectangle((tx - 1, ty - 1, tx + len(label) * 9, ty + 18), fill=(20, 20, 20))
         draw.text((tx, ty), label, fill=(255, 255, 0), font=font)
+
+
+def write_annotated_frame(frame_bgr, base_path: str, results: List[OCRText]) -> str:
+    # base_path is used for naming only; no raw image is persisted.
+    rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
+    img = Image.fromarray(rgb).convert("RGB")
+    draw = ImageDraw.Draw(img)
+    font = pick_cjk_font(16)
+    _draw_ocr_overlays(draw, results, font)
     out = build_artifact_path(base_path, "_annotated")
     img.save(out)
     return out
@@ -72,13 +76,7 @@ def write_annotated_image(image_path: str, results: List[OCRText]) -> str:
     img = Image.open(image_path).convert("RGB")
     draw = ImageDraw.Draw(img)
     font = pick_cjk_font(16)
-    for item in results:
-        b = item.box.normalized()
-        draw.rectangle((b.x1, b.y1, b.x2, b.y2), outline=(0, 80, 255), width=2)
-        label = f"{item.text} | {item.confidence:.2f}"
-        tx, ty = b.x1 + 2, max(2, b.y1 - 20)
-        draw.rectangle((tx - 1, ty - 1, tx + len(label) * 9, ty + 18), fill=(20, 20, 20))
-        draw.text((tx, ty), label, fill=(255, 255, 0), font=font)
+    _draw_ocr_overlays(draw, results, font)
     out = build_artifact_path(image_path, "_annotated")
     img.save(out)
     return out

--- a/src/ocr_helper_tool/artifacts.py
+++ b/src/ocr_helper_tool/artifacts.py
@@ -50,6 +50,24 @@ def write_raw_frame(frame_bgr, output_path: str) -> str:
     return output_path
 
 
+def write_annotated_frame(frame_bgr, base_path: str, results: List[OCRText]) -> str:
+    # base_path is used for naming only; no raw image is persisted.
+    rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
+    img = Image.fromarray(rgb).convert("RGB")
+    draw = ImageDraw.Draw(img)
+    font = pick_cjk_font(16)
+    for item in results:
+        b = item.box.normalized()
+        draw.rectangle((b.x1, b.y1, b.x2, b.y2), outline=(0, 80, 255), width=2)
+        label = f"{item.text} | {item.confidence:.2f}"
+        tx, ty = b.x1 + 2, max(2, b.y1 - 20)
+        draw.rectangle((tx - 1, ty - 1, tx + len(label) * 9, ty + 18), fill=(20, 20, 20))
+        draw.text((tx, ty), label, fill=(255, 255, 0), font=font)
+    out = build_artifact_path(base_path, "_annotated")
+    img.save(out)
+    return out
+
+
 def write_annotated_image(image_path: str, results: List[OCRText]) -> str:
     img = Image.open(image_path).convert("RGB")
     draw = ImageDraw.Draw(img)

--- a/src/ocr_helper_tool/artifacts.py
+++ b/src/ocr_helper_tool/artifacts.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import json
 import os
-import time
+from datetime import datetime
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 import cv2
 from PIL import Image, ImageDraw, ImageFont
@@ -13,10 +13,14 @@ from .geometry import pixel_box_to_rel
 from .interfaces import OCRText
 
 
-def make_timestamp_image_path(folder: str, ext: str = ".png") -> str:
+def make_timestamp_image_path(folder: str, ext: str = ".png", stem_suffix: Optional[str] = None) -> str:
     Path(folder).mkdir(parents=True, exist_ok=True)
-    ts = int(time.time() * 1000)
-    return str(Path(folder) / f"{ts}{ext}")
+    # Align with OK-WW screenshot naming: HH-MM-SS.mmm
+    ts = datetime.now().strftime("%H-%M-%S.%f")[:-3]
+    suffix = stem_suffix or ""
+    if suffix and not suffix.startswith("_"):
+        suffix = f"_{suffix}"
+    return str(Path(folder) / f"{ts}{suffix}{ext}")
 
 
 def build_artifact_path(base_image_path: str, suffix: str) -> str:

--- a/src/ocr_helper_tool/cli.py
+++ b/src/ocr_helper_tool/cli.py
@@ -1,79 +1,12 @@
 from __future__ import annotations
 
 import argparse
-import json
 import os
-from dataclasses import asdict
-from typing import List
 
 import cv2
-from PIL import Image, ImageDraw, ImageFont
 
-from .geometry import pixel_box_to_rel
-from .interfaces import OCRText
+from .artifacts import make_timestamp_image_path, write_annotated_image, write_raw_frame, write_results_json
 from .okww_adapter import OKWWOCRHelper, OCRHelperConfig
-
-
-def _pick_cjk_font(size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
-    candidates = [
-        r"C:\Windows\Fonts\msyh.ttc",
-        r"C:\Windows\Fonts\msyhbd.ttc",
-        r"C:\Windows\Fonts\simhei.ttf",
-        r"C:\Windows\Fonts\simsun.ttc",
-    ]
-    for path in candidates:
-        if os.path.exists(path):
-            try:
-                return ImageFont.truetype(path, size=size)
-            except Exception:
-                pass
-    return ImageFont.load_default()
-
-
-def write_annotated(image_path: str, results: List[OCRText]) -> str:
-    img = Image.open(image_path).convert("RGB")
-    draw = ImageDraw.Draw(img)
-    font = _pick_cjk_font(16)
-    for item in results:
-        b = item.box.normalized()
-        draw.rectangle((b.x1, b.y1, b.x2, b.y2), outline=(0, 80, 255), width=2)
-        label = f"{item.text} | {item.confidence:.2f}"
-        tx, ty = b.x1 + 2, max(2, b.y1 - 20)
-        draw.rectangle((tx - 1, ty - 1, tx + len(label) * 9, ty + 18), fill=(20, 20, 20))
-        draw.text((tx, ty), label, fill=(255, 255, 0), font=font)
-    out = image_path.replace(".png", "_annotated.png")
-    img.save(out)
-    return out
-
-
-def write_results_json(image_path: str, results: List[OCRText], frame_w: int, frame_h: int, engine: str) -> str:
-    payload = {
-        "engine": engine,
-        "frame_size": {"width": frame_w, "height": frame_h},
-        "count": len(results),
-        "items": [],
-    }
-    for item in results:
-        b = item.box.normalized()
-        rel = pixel_box_to_rel(b, frame_w, frame_h).normalized()
-        payload["items"].append(
-            {
-                "text": item.text,
-                "confidence": round(float(item.confidence), 6),
-                "pixel_box": {"x1": b.x1, "y1": b.y1, "x2": b.x2, "y2": b.y2},
-                "relative_box": {
-                    "x1": round(rel.x1, 6),
-                    "y1": round(rel.y1, 6),
-                    "x2": round(rel.x2, 6),
-                    "y2": round(rel.y2, 6),
-                },
-            }
-        )
-    out = image_path.replace(".png", "_results.json")
-    with open(out, "w", encoding="utf-8") as f:
-        json.dump(payload, f, ensure_ascii=False, indent=2)
-    return out
-
 
 def main() -> int:
     ap = argparse.ArgumentParser(description="OKWW OCR helper offline debug")
@@ -100,19 +33,17 @@ def main() -> int:
         )
     )
 
-    # Use recognize_verbose to apply repair + whitelist; it will also create a timestamp-only copy
-    # if you pass screenshot_dir. Here we OCR the provided image directly to avoid extra copies.
-    results, _raw = helper.adapter.recognize(args.image, None), args.image
-    # normalize/whitelist path is in helper.recognize_verbose; reuse that by faking a frame write
-    # Instead, run through helper.recognize_verbose by writing frame to same folder.
     results2, raw_path = helper.recognize_verbose(
         frame_bgr=frame,
         screenshot_dir=os.path.dirname(args.image) or ".",
         tag="offline",
         save_artifacts=False,
     )
+    if not raw_path:
+        raw_path = make_timestamp_image_path(os.path.dirname(args.image) or ".", ".png")
+        write_raw_frame(frame, raw_path)
 
-    annotated = write_annotated(raw_path, results2)
+    annotated = write_annotated_image(raw_path, results2)
     js = write_results_json(raw_path, results2, w, h, helper.engine_name)
     print(f"raw={raw_path}")
     print(f"annotated={annotated}")

--- a/src/ocr_helper_tool/cli.py
+++ b/src/ocr_helper_tool/cli.py
@@ -1,54 +1,212 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
+from pathlib import Path
 
 import cv2
 
 from .artifacts import make_timestamp_image_path, write_annotated_image, write_raw_frame, write_results_json
+from .interfaces import Box, OCRText
 from .okww_adapter import OKWWOCRHelper, OCRHelperConfig
+
+
+def _normalize_text(text: str) -> str:
+    out = []
+    for ch in (text or ""):
+        if ("\u4e00" <= ch <= "\u9fff") or ch.isalnum():
+            out.append(ch)
+    return "".join(out).lower()
+
+
+def _engine_snapshot(items: list[OCRText]) -> dict:
+    confs = [float(x.confidence) for x in items]
+    texts = [_normalize_text(x.text) for x in items if _normalize_text(x.text)]
+    return {
+        "count": len(items),
+        "avg_confidence": round(sum(confs) / len(confs), 6) if confs else 0.0,
+        "unique_text_count": len(set(texts)),
+        "texts": sorted(set(texts)),
+    }
+
+
+def _write_compare_report(image_path: str, report: dict) -> str:
+    p = Path(image_path)
+    out = p.with_name(f"{p.stem}_compare_report.json")
+    out.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+    return str(out)
+
+
+def _run_toolbox_ocr(frame, args, screenshot_dir: str, wl) -> tuple[list[OCRText], str, str]:
+    reliability_mode = False if args.no_reliability_mode else True if args.reliability_mode else True
+    helper = OKWWOCRHelper(
+        OCRHelperConfig(
+            engine=args.engine,
+            min_confidence=args.min_confidence,
+            reliability_mode=reliability_mode,
+            whitelist_terms=wl,
+            whitelist_confidence_floor=args.whitelist_floor,
+            whitelist_similarity=args.whitelist_similarity,
+            exact_match_confidence_boost=args.exact_boost,
+            fuzzy_match_confidence_boost=args.fuzzy_boost,
+            dedupe_iou_threshold=args.dedupe_iou,
+        )
+    )
+    results, _ = helper.recognize_verbose(
+        frame_bgr=frame,
+        screenshot_dir=screenshot_dir,
+        tag="toolbox",
+        save_artifacts=False,
+    )
+    raw_path = make_timestamp_image_path(screenshot_dir, ".png", stem_suffix="ocr_helper")
+    write_raw_frame(frame, raw_path)
+    return results, raw_path, helper.engine_name
+
+
+def _to_native_items(native_result) -> list[OCRText]:
+    out: list[OCRText] = []
+    for line in (native_result[0] if native_result else []):
+        if len(line) < 2:
+            continue
+        pts = line[0]
+        txt = str(line[1][0]).strip()
+        conf = float(line[1][1])
+        if not txt:
+            continue
+        xs = [int(p[0]) for p in pts]
+        ys = [int(p[1]) for p in pts]
+        out.append(
+            OCRText(
+                text=txt,
+                box=Box(min(xs), min(ys), max(xs), max(ys)),
+                confidence=max(0.0, min(1.0, conf)),
+                font_size=max(8, max(ys) - min(ys)),
+            )
+        )
+    return out
+
+
+def _run_native_ocr(frame, args, screenshot_dir: str) -> tuple[list[OCRText], str, str]:
+    from onnxocr.onnx_paddleocr import ONNXPaddleOcr
+
+    ocr = ONNXPaddleOcr(
+        use_angle_cls=False,
+        use_openvino=True,
+        use_npu=True,
+    )
+    native_result = ocr.ocr(frame)
+    results = _to_native_items(native_result)
+    raw_path = make_timestamp_image_path(screenshot_dir, ".png", stem_suffix="ocr_native")
+    write_raw_frame(frame, raw_path)
+    return results, raw_path, "ONNXPaddleOcr(native)"
+
 
 def main() -> int:
     ap = argparse.ArgumentParser(description="OKWW OCR helper offline debug")
     ap.add_argument("--image", required=True, help="Path to input image (.png/.jpg/...)")
+    ap.add_argument(
+        "--frontend-mode",
+        default="toolbox",
+        choices=["toolbox", "native", "both"],
+        help="Choose frontend OCR entry: B(toolbox), C(native), or both",
+    )
     ap.add_argument("--engine", default="auto", help="auto/RapidOCR/PaddleOCR/Tesseract")
     ap.add_argument("--min-confidence", type=float, default=0.0)
+    ap.add_argument("--reliability-mode", action="store_true", help="Enable multi-engine verification when engine=auto")
+    ap.add_argument("--no-reliability-mode", action="store_true", help="Disable reliability mode")
+    ap.add_argument("--dev-compare", action="store_true", help="Run Rapid/Paddle/Tesseract side-by-side and save compare report")
     ap.add_argument("--whitelist", default="", help="Comma-separated whitelist terms")
     ap.add_argument("--whitelist-floor", type=float, default=0.85)
     ap.add_argument("--whitelist-similarity", type=float, default=0.62)
+    ap.add_argument("--exact-boost", type=float, default=0.08, help="Confidence boost for exact whitelist matches")
+    ap.add_argument("--fuzzy-boost", type=float, default=0.03, help="Confidence boost for fuzzy whitelist matches")
+    ap.add_argument("--dedupe-iou", type=float, default=0.55, help="IOU threshold for same-text dedupe")
+    ap.add_argument("--output-dir", default="screenshots", help="Directory to save OCR artifacts")
     args = ap.parse_args()
 
     frame = cv2.imread(args.image)
     if frame is None:
         raise SystemExit(f"Failed to read image: {args.image}")
     h, w = frame.shape[:2]
+    screenshot_dir = args.output_dir or "screenshots"
     wl = [s.strip() for s in args.whitelist.split(",") if s.strip()] or None
-    helper = OKWWOCRHelper(
-        OCRHelperConfig(
-            engine=args.engine,
-            min_confidence=args.min_confidence,
-            whitelist_terms=wl,
-            whitelist_confidence_floor=args.whitelist_floor,
-            whitelist_similarity=args.whitelist_similarity,
-        )
-    )
+    reliability_mode = False if args.no_reliability_mode else True if args.reliability_mode else True
 
-    results2, raw_path = helper.recognize_verbose(
-        frame_bgr=frame,
-        screenshot_dir=os.path.dirname(args.image) or ".",
-        tag="offline",
-        save_artifacts=False,
-    )
-    if not raw_path:
-        raw_path = make_timestamp_image_path(os.path.dirname(args.image) or ".", ".png")
-        write_raw_frame(frame, raw_path)
+    outputs: dict[str, dict] = {}
+    if args.frontend_mode in ("toolbox", "both"):
+        res_b, raw_b, engine_b = _run_toolbox_ocr(frame, args, screenshot_dir, wl)
+        outputs["toolbox"] = {
+            "raw": raw_b,
+            "annotated": write_annotated_image(raw_b, res_b),
+            "json": write_results_json(raw_b, res_b, w, h, engine_b),
+            "count": len(res_b),
+            "engine": engine_b,
+        }
+    if args.frontend_mode in ("native", "both"):
+        res_c, raw_c, engine_c = _run_native_ocr(frame, args, screenshot_dir)
+        outputs["native"] = {
+            "raw": raw_c,
+            "annotated": write_annotated_image(raw_c, res_c),
+            "json": write_results_json(raw_c, res_c, w, h, engine_c),
+            "count": len(res_c),
+            "engine": engine_c,
+        }
 
-    annotated = write_annotated_image(raw_path, results2)
-    js = write_results_json(raw_path, results2, w, h, helper.engine_name)
-    print(f"raw={raw_path}")
-    print(f"annotated={annotated}")
-    print(f"json={js}")
-    print(f"count={len(results2)} engine={helper.engine_name}")
+    for mode, info in outputs.items():
+        print(f"[{mode}] raw={info['raw']}")
+        print(f"[{mode}] annotated={info['annotated']}")
+        print(f"[{mode}] json={info['json']}")
+        print(f"[{mode}] count={info['count']} engine={info['engine']}")
+
+    if args.dev_compare:
+        if args.frontend_mode == "native":
+            print("dev_compare is only for toolbox engines; skip in native-only mode.")
+            return 0
+        engines = ["RapidOCR", "PaddleOCR", "Tesseract"]
+        snapshots = {}
+        for eng in engines:
+            h2 = OKWWOCRHelper(
+                OCRHelperConfig(
+                    engine=eng,
+                    min_confidence=args.min_confidence,
+                    reliability_mode=False,
+                    whitelist_terms=wl,
+                    whitelist_confidence_floor=args.whitelist_floor,
+                    whitelist_similarity=args.whitelist_similarity,
+                    exact_match_confidence_boost=args.exact_boost,
+                    fuzzy_match_confidence_boost=args.fuzzy_boost,
+                    dedupe_iou_threshold=args.dedupe_iou,
+                )
+            )
+            if h2.engine_name == "Dummy":
+                snapshots[eng] = {"available": False, "count": 0, "avg_confidence": 0.0, "unique_text_count": 0, "texts": []}
+                continue
+            r2, _ = h2.recognize_verbose(
+                frame_bgr=frame,
+                screenshot_dir=screenshot_dir,
+                tag=f"compare_{eng}",
+                save_artifacts=False,
+            )
+            snap = _engine_snapshot(r2)
+            snap["available"] = True
+            snapshots[eng] = snap
+        available_sets = [set(v["texts"]) for v in snapshots.values() if v.get("available")]
+        common_all = sorted(list(set.intersection(*available_sets))) if len(available_sets) >= 2 else []
+        selected = outputs.get("toolbox") or next(iter(outputs.values()))
+        report = {
+            "image": args.image,
+            "frontend_mode": args.frontend_mode,
+            "selected_engine": selected["engine"],
+            "selected_engine_count": selected["count"],
+            "reliability_mode": reliability_mode,
+            "engines": snapshots,
+            "common_texts_all_engines": common_all,
+            "common_texts_count": len(common_all),
+            "available_engines_count": sum(1 for v in snapshots.values() if v.get("available")),
+        }
+        report_path = _write_compare_report(selected["raw"], report)
+        print(f"compare_report={report_path}")
     return 0
 
 

--- a/src/ocr_helper_tool/cli.py
+++ b/src/ocr_helper_tool/cli.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from dataclasses import asdict
+from typing import List
+
+import cv2
+from PIL import Image, ImageDraw, ImageFont
+
+from .geometry import pixel_box_to_rel
+from .interfaces import OCRText
+from .okww_adapter import OKWWOCRHelper, OCRHelperConfig
+
+
+def _pick_cjk_font(size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    candidates = [
+        r"C:\Windows\Fonts\msyh.ttc",
+        r"C:\Windows\Fonts\msyhbd.ttc",
+        r"C:\Windows\Fonts\simhei.ttf",
+        r"C:\Windows\Fonts\simsun.ttc",
+    ]
+    for path in candidates:
+        if os.path.exists(path):
+            try:
+                return ImageFont.truetype(path, size=size)
+            except Exception:
+                pass
+    return ImageFont.load_default()
+
+
+def write_annotated(image_path: str, results: List[OCRText]) -> str:
+    img = Image.open(image_path).convert("RGB")
+    draw = ImageDraw.Draw(img)
+    font = _pick_cjk_font(16)
+    for item in results:
+        b = item.box.normalized()
+        draw.rectangle((b.x1, b.y1, b.x2, b.y2), outline=(0, 80, 255), width=2)
+        label = f"{item.text} | {item.confidence:.2f}"
+        tx, ty = b.x1 + 2, max(2, b.y1 - 20)
+        draw.rectangle((tx - 1, ty - 1, tx + len(label) * 9, ty + 18), fill=(20, 20, 20))
+        draw.text((tx, ty), label, fill=(255, 255, 0), font=font)
+    out = image_path.replace(".png", "_annotated.png")
+    img.save(out)
+    return out
+
+
+def write_results_json(image_path: str, results: List[OCRText], frame_w: int, frame_h: int, engine: str) -> str:
+    payload = {
+        "engine": engine,
+        "frame_size": {"width": frame_w, "height": frame_h},
+        "count": len(results),
+        "items": [],
+    }
+    for item in results:
+        b = item.box.normalized()
+        rel = pixel_box_to_rel(b, frame_w, frame_h).normalized()
+        payload["items"].append(
+            {
+                "text": item.text,
+                "confidence": round(float(item.confidence), 6),
+                "pixel_box": {"x1": b.x1, "y1": b.y1, "x2": b.x2, "y2": b.y2},
+                "relative_box": {
+                    "x1": round(rel.x1, 6),
+                    "y1": round(rel.y1, 6),
+                    "x2": round(rel.x2, 6),
+                    "y2": round(rel.y2, 6),
+                },
+            }
+        )
+    out = image_path.replace(".png", "_results.json")
+    with open(out, "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="OKWW OCR helper offline debug")
+    ap.add_argument("--image", required=True, help="Path to input image (.png/.jpg/...)")
+    ap.add_argument("--engine", default="auto", help="auto/RapidOCR/PaddleOCR/Tesseract")
+    ap.add_argument("--min-confidence", type=float, default=0.0)
+    ap.add_argument("--whitelist", default="", help="Comma-separated whitelist terms")
+    ap.add_argument("--whitelist-floor", type=float, default=0.85)
+    ap.add_argument("--whitelist-similarity", type=float, default=0.62)
+    args = ap.parse_args()
+
+    frame = cv2.imread(args.image)
+    if frame is None:
+        raise SystemExit(f"Failed to read image: {args.image}")
+    h, w = frame.shape[:2]
+    wl = [s.strip() for s in args.whitelist.split(",") if s.strip()] or None
+    helper = OKWWOCRHelper(
+        OCRHelperConfig(
+            engine=args.engine,
+            min_confidence=args.min_confidence,
+            whitelist_terms=wl,
+            whitelist_confidence_floor=args.whitelist_floor,
+            whitelist_similarity=args.whitelist_similarity,
+        )
+    )
+
+    # Use recognize_verbose to apply repair + whitelist; it will also create a timestamp-only copy
+    # if you pass screenshot_dir. Here we OCR the provided image directly to avoid extra copies.
+    results, _raw = helper.adapter.recognize(args.image, None), args.image
+    # normalize/whitelist path is in helper.recognize_verbose; reuse that by faking a frame write
+    # Instead, run through helper.recognize_verbose by writing frame to same folder.
+    results2, raw_path = helper.recognize_verbose(
+        frame_bgr=frame,
+        screenshot_dir=os.path.dirname(args.image) or ".",
+        tag="offline",
+        save_artifacts=False,
+    )
+
+    annotated = write_annotated(raw_path, results2)
+    js = write_results_json(raw_path, results2, w, h, helper.engine_name)
+    print(f"raw={raw_path}")
+    print(f"annotated={annotated}")
+    print(f"json={js}")
+    print(f"count={len(results2)} engine={helper.engine_name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/src/ocr_helper_tool/cli.py
+++ b/src/ocr_helper_tool/cli.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import cv2
 
-from .artifacts import make_timestamp_image_path, write_annotated_image, write_raw_frame, write_results_json
+from .artifacts import make_timestamp_image_path, write_annotated_frame, write_results_json
 from .interfaces import Box, OCRText
 from .okww_adapter import OKWWOCRHelper, OCRHelperConfig
 
@@ -59,9 +59,8 @@ def _run_toolbox_ocr(frame, args, screenshot_dir: str, wl) -> tuple[list[OCRText
         tag="toolbox",
         save_artifacts=False,
     )
-    raw_path = make_timestamp_image_path(screenshot_dir, ".png", stem_suffix="ocr_helper")
-    write_raw_frame(frame, raw_path)
-    return results, raw_path, helper.engine_name
+    base_path = make_timestamp_image_path(screenshot_dir, ".png", stem_suffix="ocr_helper")
+    return results, base_path, helper.engine_name
 
 
 def _to_native_items(native_result) -> list[OCRText]:
@@ -97,9 +96,8 @@ def _run_native_ocr(frame, args, screenshot_dir: str) -> tuple[list[OCRText], st
     )
     native_result = ocr.ocr(frame)
     results = _to_native_items(native_result)
-    raw_path = make_timestamp_image_path(screenshot_dir, ".png", stem_suffix="ocr_native")
-    write_raw_frame(frame, raw_path)
-    return results, raw_path, "ONNXPaddleOcr(native)"
+    base_path = make_timestamp_image_path(screenshot_dir, ".png", stem_suffix="ocr_native")
+    return results, base_path, "ONNXPaddleOcr(native)"
 
 
 def main() -> int:
@@ -135,26 +133,23 @@ def main() -> int:
 
     outputs: dict[str, dict] = {}
     if args.frontend_mode in ("toolbox", "both"):
-        res_b, raw_b, engine_b = _run_toolbox_ocr(frame, args, screenshot_dir, wl)
+        res_b, base_b, engine_b = _run_toolbox_ocr(frame, args, screenshot_dir, wl)
         outputs["toolbox"] = {
-            "raw": raw_b,
-            "annotated": write_annotated_image(raw_b, res_b),
-            "json": write_results_json(raw_b, res_b, w, h, engine_b),
+            "annotated": write_annotated_frame(frame, base_b, res_b),
+            "json": write_results_json(base_b, res_b, w, h, engine_b),
             "count": len(res_b),
             "engine": engine_b,
         }
     if args.frontend_mode in ("native", "both"):
-        res_c, raw_c, engine_c = _run_native_ocr(frame, args, screenshot_dir)
+        res_c, base_c, engine_c = _run_native_ocr(frame, args, screenshot_dir)
         outputs["native"] = {
-            "raw": raw_c,
-            "annotated": write_annotated_image(raw_c, res_c),
-            "json": write_results_json(raw_c, res_c, w, h, engine_c),
+            "annotated": write_annotated_frame(frame, base_c, res_c),
+            "json": write_results_json(base_c, res_c, w, h, engine_c),
             "count": len(res_c),
             "engine": engine_c,
         }
 
     for mode, info in outputs.items():
-        print(f"[{mode}] raw={info['raw']}")
         print(f"[{mode}] annotated={info['annotated']}")
         print(f"[{mode}] json={info['json']}")
         print(f"[{mode}] count={info['count']} engine={info['engine']}")
@@ -205,7 +200,8 @@ def main() -> int:
             "common_texts_count": len(common_all),
             "available_engines_count": sum(1 for v in snapshots.values() if v.get("available")),
         }
-        report_path = _write_compare_report(selected["raw"], report)
+        # Anchor compare report to the annotated image path (always persisted).
+        report_path = _write_compare_report(selected["annotated"], report)
         print(f"compare_report={report_path}")
     return 0
 

--- a/src/ocr_helper_tool/cli.py
+++ b/src/ocr_helper_tool/cli.py
@@ -10,19 +10,12 @@ import cv2
 from .artifacts import make_timestamp_image_path, write_annotated_frame, write_results_json
 from .interfaces import Box, OCRText
 from .okww_adapter import OKWWOCRHelper, OCRHelperConfig
-
-
-def _normalize_text(text: str) -> str:
-    out = []
-    for ch in (text or ""):
-        if ("\u4e00" <= ch <= "\u9fff") or ch.isalnum():
-            out.append(ch)
-    return "".join(out).lower()
+from .text_utils import normalize_text_for_compare
 
 
 def _engine_snapshot(items: list[OCRText]) -> dict:
     confs = [float(x.confidence) for x in items]
-    texts = [_normalize_text(x.text) for x in items if _normalize_text(x.text)]
+    texts = [normalize_text_for_compare(x.text) for x in items if normalize_text_for_compare(x.text)]
     return {
         "count": len(items),
         "avg_confidence": round(sum(confs) / len(confs), 6) if confs else 0.0,
@@ -148,6 +141,8 @@ def main() -> int:
             "count": len(res_c),
             "engine": engine_c,
         }
+    if not outputs:
+        raise SystemExit("No OCR output generated. Check frontend mode and input image.")
 
     for mode, info in outputs.items():
         print(f"[{mode}] annotated={info['annotated']}")

--- a/src/ocr_helper_tool/cli.py
+++ b/src/ocr_helper_tool/cli.py
@@ -32,7 +32,7 @@ def _write_compare_report(image_path: str, report: dict) -> str:
 
 
 def _run_toolbox_ocr(frame, args, screenshot_dir: str, wl) -> tuple[list[OCRText], str, str]:
-    reliability_mode = False if args.no_reliability_mode else True if args.reliability_mode else True
+    reliability_mode = not args.no_reliability_mode
     helper = OKWWOCRHelper(
         OCRHelperConfig(
             engine=args.engine,
@@ -122,7 +122,7 @@ def main() -> int:
     h, w = frame.shape[:2]
     screenshot_dir = args.output_dir or "screenshots"
     wl = [s.strip() for s in args.whitelist.split(",") if s.strip()] or None
-    reliability_mode = False if args.no_reliability_mode else True if args.reliability_mode else True
+    reliability_mode = not args.no_reliability_mode
 
     outputs: dict[str, dict] = {}
     if args.frontend_mode in ("toolbox", "both"):

--- a/src/ocr_helper_tool/core.py
+++ b/src/ocr_helper_tool/core.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from PIL import Image
+
+from .interfaces import Box, OCRAdapter, OCRText
+
+COMMON_RESOLUTIONS: Dict[str, Tuple[int, int]] = {
+    "原始尺寸": (0, 0),
+    "1920 x 1080 (FHD)": (1920, 1080),
+    "2560 x 1440 (QHD)": (2560, 1440),
+    "3840 x 2160 (4K)": (3840, 2160),
+    "1280 x 720 (HD)": (1280, 720),
+    "1080 x 1920 (手机竖屏)": (1080, 1920),
+    "1440 x 2560 (手机高分辨率)": (1440, 2560),
+}
+
+
+@dataclass
+class OCRSession:
+    image_path: Optional[Path] = None
+    display_resolution: str = "原始尺寸"
+    selected_box: Optional[Box] = None
+    ocr_adapter: Optional[OCRAdapter] = None
+    _image_size: Tuple[int, int] = field(default_factory=lambda: (0, 0))
+    ocr_results: List[OCRText] = field(default_factory=list)
+
+    def load_image(self, image_path: str) -> None:
+        path = Path(image_path).expanduser().resolve()
+        if not path.exists():
+            raise FileNotFoundError(f"Image does not exist: {path}")
+        self.image_path = path
+        with Image.open(path) as img:
+            self._image_size = img.size
+        self.selected_box = None
+        self.ocr_results = []
+
+    @property
+    def image_size(self) -> Tuple[int, int]:
+        return self._image_size
+
+    def set_resolution(self, resolution_label: str) -> None:
+        if resolution_label not in COMMON_RESOLUTIONS:
+            raise ValueError(f"Unsupported resolution option: {resolution_label}")
+        self.display_resolution = resolution_label
+
+    def update_selection(self, box: Box) -> None:
+        self.selected_box = box.normalized()
+
+    def run_ocr(self, region: Optional[Box] = None) -> List[OCRText]:
+        if self.image_path is None:
+            raise RuntimeError("No image loaded.")
+        if self.ocr_adapter is None:
+            raise RuntimeError("No OCR adapter configured.")
+        target_region = region
+        if target_region is None and self.selected_box is not None:
+            target_region = self.selected_box
+        self.ocr_results = self.ocr_adapter.recognize(str(self.image_path), target_region)
+        return self.ocr_results
+
+    def run_full_ocr(self) -> List[OCRText]:
+        return self.run_ocr(region=None)
+
+    def target_canvas_size(self) -> Tuple[int, int]:
+        if self.display_resolution == "原始尺寸":
+            return self._image_size
+        return COMMON_RESOLUTIONS[self.display_resolution]
+

--- a/src/ocr_helper_tool/geometry.py
+++ b/src/ocr_helper_tool/geometry.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .interfaces import Box
+
+
+@dataclass(frozen=True)
+class RelBox:
+    """Relative box coordinates in [0,1] for the full frame."""
+
+    x1: float
+    y1: float
+    x2: float
+    y2: float
+
+    def normalized(self) -> "RelBox":
+        left = min(self.x1, self.x2)
+        right = max(self.x1, self.x2)
+        top = min(self.y1, self.y2)
+        bottom = max(self.y1, self.y2)
+        return RelBox(left, top, right, bottom)
+
+
+def pixel_box_to_rel(box: Box, frame_width: int, frame_height: int) -> RelBox:
+    if frame_width <= 0 or frame_height <= 0:
+        raise ValueError("frame_width/frame_height must be > 0")
+    b = box.normalized()
+    return RelBox(
+        x1=b.x1 / frame_width,
+        y1=b.y1 / frame_height,
+        x2=b.x2 / frame_width,
+        y2=b.y2 / frame_height,
+    )
+
+
+def rel_box_to_pixel(box: RelBox, frame_width: int, frame_height: int) -> Box:
+    if frame_width <= 0 or frame_height <= 0:
+        raise ValueError("frame_width/frame_height must be > 0")
+    b = box.normalized()
+    return Box(
+        int(round(b.x1 * frame_width)),
+        int(round(b.y1 * frame_height)),
+        int(round(b.x2 * frame_width)),
+        int(round(b.y2 * frame_height)),
+    )
+

--- a/src/ocr_helper_tool/interfaces.py
+++ b/src/ocr_helper_tool/interfaces.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Protocol
+
+
+@dataclass(frozen=True)
+class Box:
+    """Pixel-space box (x1,y1,x2,y2)."""
+
+    x1: int
+    y1: int
+    x2: int
+    y2: int
+
+    @property
+    def width(self) -> int:
+        return abs(self.x2 - self.x1)
+
+    @property
+    def height(self) -> int:
+        return abs(self.y2 - self.y1)
+
+    def normalized(self) -> "Box":
+        left = min(self.x1, self.x2)
+        right = max(self.x1, self.x2)
+        top = min(self.y1, self.y2)
+        bottom = max(self.y1, self.y2)
+        return Box(left, top, right, bottom)
+
+
+@dataclass(frozen=True)
+class OCRText:
+    text: str
+    box: Box
+    confidence: float
+    font_size: int
+
+
+class OCRAdapter(Protocol):
+    def recognize(self, image_path: str, region: Optional[Box] = None) -> List[OCRText]:
+        """Execute OCR on image_path. If region is given, limit OCR to that region."""
+

--- a/src/ocr_helper_tool/interfaces.py
+++ b/src/ocr_helper_tool/interfaces.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Optional, Protocol
+from typing import Any, List, Optional, Protocol, Union
 
 
 @dataclass(frozen=True)
@@ -37,7 +37,10 @@ class OCRText:
     font_size: int
 
 
+ImageInput = Union[str, Any]
+
+
 class OCRAdapter(Protocol):
-    def recognize(self, image_path: str, region: Optional[Box] = None) -> List[OCRText]:
-        """Execute OCR on image_path. If region is given, limit OCR to that region."""
+    def recognize(self, image: ImageInput, region: Optional[Box] = None) -> List[OCRText]:
+        """Execute OCR on image input (path or in-memory image)."""
 

--- a/src/ocr_helper_tool/okww_adapter.py
+++ b/src/ocr_helper_tool/okww_adapter.py
@@ -18,9 +18,13 @@ MatchType = Union[str, Pattern[str], Iterable[Union[str, Pattern[str]]]]
 class OCRHelperConfig:
     engine: str = "auto"  # auto/RapidOCR/PaddleOCR/Tesseract
     min_confidence: float = 0.0
+    reliability_mode: bool = False
     whitelist_terms: Optional[List[str]] = None
     whitelist_similarity: float = 0.62
     whitelist_confidence_floor: float = 0.85
+    exact_match_confidence_boost: float = 0.08
+    fuzzy_match_confidence_boost: float = 0.03
+    dedupe_iou_threshold: float = 0.55
     save_artifacts_on_verbose: bool = True
 
 
@@ -46,6 +50,7 @@ class OKWWOCRHelper:
     def __init__(self, config: OCRHelperConfig) -> None:
         self.config = config
         self.adapter, self.engine_name, self.engine_status = create_ocr_adapter(config.engine)
+        self._fallback_adapters = self._build_fallback_adapters()
 
     def recognize(
         self,
@@ -91,6 +96,13 @@ class OKWWOCRHelper:
 
         # In-memory OCR by default; avoid disk IO in high-frequency loops.
         results: List[OCRText] = self.adapter.recognize(frame_bgr, helper_region)
+        if self.config.reliability_mode and self._fallback_adapters:
+            for adapter in self._fallback_adapters:
+                try:
+                    fallback_results = adapter.recognize(frame_bgr, helper_region)
+                    results = _merge_results(results, fallback_results)
+                except Exception:
+                    continue
         fixed_results: List[OCRText] = []
         for item in results:
             fixed_text, fixed_confidence = self._normalize_and_whitelist(item.text, item.confidence)
@@ -102,23 +114,43 @@ class OKWWOCRHelper:
                     font_size=item.font_size,
                 )
             )
+        fixed_results = _dedupe_results(fixed_results, self.config.dedupe_iou_threshold)
         image_path = ""
         should_save_artifacts = self.config.save_artifacts_on_verbose if save_artifacts is None else save_artifacts
         if should_save_artifacts:
-            image_path = make_timestamp_image_path(screenshot_dir, ".png")
+            image_path = make_timestamp_image_path(screenshot_dir, ".png", stem_suffix="ocr_helper")
             write_raw_frame(frame_bgr, image_path)
             write_annotated_image(image_path, fixed_results)
             write_results_json(image_path, fixed_results, frame_bgr.shape[1], frame_bgr.shape[0], self.engine_name)
         return fixed_results, image_path
 
+    def _build_fallback_adapters(self):
+        if self.config.engine != "auto":
+            return []
+        fallbacks = []
+        for engine in ("RapidOCR", "PaddleOCR"):
+            if engine == self.engine_name:
+                continue
+            try:
+                adapter, resolved_name, _ = create_ocr_adapter(engine)
+                if resolved_name == "Dummy":
+                    continue
+                fallbacks.append(adapter)
+            except Exception:
+                continue
+        return fallbacks
+
     def _normalize_and_whitelist(self, text: str, confidence: float) -> tuple[str, float]:
         repaired = _repair_text((text or "").strip())
         whitelist = self.config.whitelist_terms or DEFAULT_OCR_WHITELIST
-        matched = _match_whitelist(repaired, whitelist, self.config.whitelist_similarity)
+        conf = max(0.0, min(1.0, float(confidence)))
+        matched, score, is_exact = _match_whitelist_detail(repaired, whitelist, self.config.whitelist_similarity)
         if matched is not None:
-            boosted = max(float(confidence), float(self.config.whitelist_confidence_floor))
-            return matched, boosted
-        return repaired, float(confidence)
+            conf = max(conf, float(self.config.whitelist_confidence_floor))
+            boost = self.config.exact_match_confidence_boost if is_exact else self.config.fuzzy_match_confidence_boost
+            conf = max(0.0, min(1.0, conf + float(boost)))
+            return matched, conf
+        return repaired, conf
 
 
 def _match_text(text: str, match: MatchType) -> bool:
@@ -184,28 +216,95 @@ def _normalize_for_compare(text: str) -> str:
     return "".join(chars).lower()
 
 
-def _match_whitelist(text: str, whitelist: List[str], threshold: float) -> Optional[str]:
+def _match_whitelist_detail(text: str, whitelist: List[str], threshold: float) -> tuple[Optional[str], float, bool]:
     src = _normalize_for_compare(text)
     if not src:
-        return None
+        return None, 0.0, False
 
     best_term: Optional[str] = None
     best_score = 0.0
+    best_exact = False
     for term in whitelist:
         target = _normalize_for_compare(term)
         if not target:
             continue
 
         if src == target or (len(target) >= 2 and target in src) or (len(src) >= 2 and src in target):
-            return term
+            return term, 1.0, True
 
         score = SequenceMatcher(None, src, target).ratio()
         if score > best_score:
             best_score = score
             best_term = term
+            best_exact = False
     if best_term is not None and best_score >= threshold:
-        return best_term
-    return None
+        return best_term, best_score, best_exact
+    return None, 0.0, False
+
+
+def _dedupe_results(results: List[OCRText], iou_threshold: float) -> List[OCRText]:
+    if not results:
+        return results
+    thr = max(0.0, min(1.0, float(iou_threshold)))
+    ordered = sorted(results, key=lambda x: float(x.confidence), reverse=True)
+    kept: List[OCRText] = []
+    for cand in ordered:
+        c_text = _normalize_for_compare(cand.text)
+        c_box = cand.box.normalized()
+        drop = False
+        for exist in kept:
+            if _normalize_for_compare(exist.text) != c_text:
+                continue
+            e_box = exist.box.normalized()
+            if _box_iou(c_box, e_box) >= thr or _box_contains(e_box, c_box):
+                drop = True
+                break
+        if not drop:
+            kept.append(cand)
+    return kept
+
+
+def _merge_results(primary: List[OCRText], secondary: List[OCRText]) -> List[OCRText]:
+    if not secondary:
+        return primary
+    merged = list(primary)
+    for cand in secondary:
+        cand_text = _normalize_for_compare(cand.text)
+        cand_box = cand.box.normalized()
+        replaced = False
+        for idx, exist in enumerate(merged):
+            if _normalize_for_compare(exist.text) != cand_text:
+                continue
+            overlap = _box_iou(exist.box.normalized(), cand_box)
+            if overlap >= 0.4 and cand.confidence > exist.confidence:
+                merged[idx] = cand
+                replaced = True
+                break
+        if not replaced:
+            merged.append(cand)
+    return merged
+
+
+def _box_iou(a: Box, b: Box) -> float:
+    ax1, ay1, ax2, ay2 = a.x1, a.y1, a.x2, a.y2
+    bx1, by1, bx2, by2 = b.x1, b.y1, b.x2, b.y2
+    inter_x1 = max(ax1, bx1)
+    inter_y1 = max(ay1, by1)
+    inter_x2 = min(ax2, bx2)
+    inter_y2 = min(ay2, by2)
+    inter_w = max(0, inter_x2 - inter_x1)
+    inter_h = max(0, inter_y2 - inter_y1)
+    inter = inter_w * inter_h
+    if inter <= 0:
+        return 0.0
+    area_a = max(1, (ax2 - ax1) * (ay2 - ay1))
+    area_b = max(1, (bx2 - bx1) * (by2 - by1))
+    union = area_a + area_b - inter
+    return float(inter) / float(max(1, union))
+
+
+def _box_contains(outer: Box, inner: Box) -> bool:
+    return outer.x1 <= inner.x1 and outer.y1 <= inner.y1 and outer.x2 >= inner.x2 and outer.y2 >= inner.y2
 
 
 

--- a/src/ocr_helper_tool/okww_adapter.py
+++ b/src/ocr_helper_tool/okww_adapter.py
@@ -8,7 +8,7 @@ from typing import Iterable, List, Optional, Pattern, Union
 from ok import Box as OKBox
 
 from .adapters import create_ocr_adapter
-from .artifacts import make_timestamp_image_path, write_annotated_image, write_raw_frame, write_results_json
+from .artifacts import make_timestamp_image_path, write_annotated_frame, write_results_json
 from .interfaces import Box, OCRText
 
 MatchType = Union[str, Pattern[str], Iterable[Union[str, Pattern[str]]]]
@@ -118,10 +118,10 @@ class OKWWOCRHelper:
         image_path = ""
         should_save_artifacts = self.config.save_artifacts_on_verbose if save_artifacts is None else save_artifacts
         if should_save_artifacts:
-            image_path = make_timestamp_image_path(screenshot_dir, ".png", stem_suffix="ocr_helper")
-            write_raw_frame(frame_bgr, image_path)
-            write_annotated_image(image_path, fixed_results)
-            write_results_json(image_path, fixed_results, frame_bgr.shape[1], frame_bgr.shape[0], self.engine_name)
+            base_path = make_timestamp_image_path(screenshot_dir, ".png", stem_suffix="ocr_helper")
+            annotated = write_annotated_frame(frame_bgr, base_path, fixed_results)
+            write_results_json(base_path, fixed_results, frame_bgr.shape[1], frame_bgr.shape[0], self.engine_name)
+            return fixed_results, annotated
         return fixed_results, image_path
 
     def _build_fallback_adapters(self):

--- a/src/ocr_helper_tool/okww_adapter.py
+++ b/src/ocr_helper_tool/okww_adapter.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import os
+import re
+import time
+import json
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from pathlib import Path
+from typing import Any, Iterable, List, Optional, Pattern, Union
+
+import cv2
+from PIL import Image, ImageDraw, ImageFont
+
+from ok import Box as OKBox
+
+from .adapters import create_ocr_adapter
+from .geometry import pixel_box_to_rel
+from .interfaces import Box, OCRText
+
+MatchType = Union[str, Pattern[str], Iterable[Union[str, Pattern[str]]]]
+
+
+@dataclass
+class OCRHelperConfig:
+    engine: str = "auto"  # auto/RapidOCR/PaddleOCR/Tesseract
+    min_confidence: float = 0.0
+    whitelist_terms: Optional[List[str]] = None
+    whitelist_similarity: float = 0.62
+    whitelist_confidence_floor: float = 0.85
+    save_artifacts_on_verbose: bool = True
+
+
+DEFAULT_OCR_WHITELIST = [
+    "领取",
+    "登录游戏",
+    "活跃度",
+    "开始游戏",
+    "进入游戏",
+    "确认",
+    "同意",
+    "特征码",
+]
+
+
+class OKWWOCRHelper:
+    """
+    Bridge ocr_helper_tool engines into okww:
+    - input: numpy BGR frame (task.frame), optional OKBox region (pixel)
+    - output: List[ok.Box] where Box.name is recognized text
+    """
+
+    def __init__(self, config: OCRHelperConfig) -> None:
+        self.config = config
+        self.adapter, self.engine_name, self.engine_status = create_ocr_adapter(config.engine)
+
+    def recognize(
+        self,
+        frame_bgr,
+        region: Optional[OKBox] = None,
+        match: Optional[MatchType] = None,
+        screenshot_dir: str = "screenshots",
+        tag: str = "ocr_helper",
+    ) -> List[OKBox]:
+        results, _image_path = self.recognize_verbose(
+            frame_bgr=frame_bgr,
+            region=region,
+            screenshot_dir=screenshot_dir,
+            tag=tag,
+        )
+        out: List[OKBox] = []
+        for item in results:
+            if item.confidence < self.config.min_confidence:
+                continue
+            text = (item.text or "").strip()
+            if not text:
+                continue
+            if match is not None and not _match_text(text, match):
+                continue
+            b = item.box.normalized()
+            out.append(OKBox(b.x1, b.y1, b.width, b.height, name=text))
+        return out
+
+    def recognize_verbose(
+        self,
+        frame_bgr,
+        region: Optional[OKBox] = None,
+        screenshot_dir: str = "screenshots",
+        tag: str = "ocr_helper",
+        save_artifacts: Optional[bool] = None,
+    ) -> tuple[List[OCRText], str]:
+        if frame_bgr is None:
+            return [], ""
+
+        # Persist the frame to disk (adapters use image_path).
+        Path(screenshot_dir).mkdir(parents=True, exist_ok=True)
+        ts = int(time.time() * 1000)
+        # Keep filename minimal for quick sorting: timestamp only.
+        image_path = os.path.join(screenshot_dir, f"{ts}.png")
+        cv2.imwrite(image_path, frame_bgr)
+
+        helper_region: Optional[Box] = None
+        if region is not None:
+            helper_region = Box(int(region.x), int(region.y), int(region.x + region.width), int(region.y + region.height))
+
+        results: List[OCRText] = self.adapter.recognize(image_path, helper_region)
+        fixed_results: List[OCRText] = []
+        for item in results:
+            fixed_text, fixed_confidence = self._normalize_and_whitelist(item.text, item.confidence)
+            fixed_results.append(
+                OCRText(
+                    text=fixed_text,
+                    box=item.box,
+                    confidence=fixed_confidence,
+                    font_size=item.font_size,
+                )
+            )
+        should_save_artifacts = self.config.save_artifacts_on_verbose if save_artifacts is None else save_artifacts
+        if should_save_artifacts:
+            self._write_annotated_image(image_path, fixed_results)
+            self._write_results_json(image_path, fixed_results, frame_bgr.shape[1], frame_bgr.shape[0])
+        return fixed_results, image_path
+
+    def _normalize_and_whitelist(self, text: str, confidence: float) -> tuple[str, float]:
+        repaired = _repair_text((text or "").strip())
+        whitelist = self.config.whitelist_terms or DEFAULT_OCR_WHITELIST
+        matched = _match_whitelist(repaired, whitelist, self.config.whitelist_similarity)
+        if matched is not None:
+            boosted = max(float(confidence), float(self.config.whitelist_confidence_floor))
+            return matched, boosted
+        return repaired, float(confidence)
+
+    def _write_annotated_image(self, raw_path: str, results: List[OCRText]) -> str:
+        img = Image.open(raw_path).convert("RGB")
+        draw = ImageDraw.Draw(img)
+        font = _pick_cjk_font(16)
+        for item in results:
+            b = item.box.normalized()
+            draw.rectangle((b.x1, b.y1, b.x2, b.y2), outline=(0, 80, 255), width=2)
+            label = f"{item.text} | {item.confidence:.2f}"
+            tx, ty = b.x1 + 2, max(2, b.y1 - 20)
+            draw.rectangle((tx - 1, ty - 1, tx + len(label) * 9, ty + 18), fill=(20, 20, 20))
+            draw.text((tx, ty), label, fill=(255, 255, 0), font=font)
+        out = raw_path.replace(".png", "_annotated.png")
+        img.save(out)
+        return out
+
+    def _write_results_json(self, raw_path: str, results: List[OCRText], frame_w: int, frame_h: int) -> str:
+        payload = {
+            "engine": self.engine_name,
+            "frame_size": {"width": frame_w, "height": frame_h},
+            "count": len(results),
+            "items": [],
+        }
+        for item in results:
+            b = item.box.normalized()
+            rel = pixel_box_to_rel(b, frame_w, frame_h).normalized()
+            payload["items"].append(
+                {
+                    "text": item.text,
+                    "confidence": round(float(item.confidence), 6),
+                    "pixel_box": {"x1": b.x1, "y1": b.y1, "x2": b.x2, "y2": b.y2},
+                    "relative_box": {
+                        "x1": round(rel.x1, 6),
+                        "y1": round(rel.y1, 6),
+                        "x2": round(rel.x2, 6),
+                        "y2": round(rel.y2, 6),
+                    },
+                }
+            )
+        out = raw_path.replace(".png", "_results.json")
+        with open(out, "w", encoding="utf-8") as f:
+            json.dump(payload, f, ensure_ascii=False, indent=2)
+        return out
+
+
+def _match_text(text: str, match: MatchType) -> bool:
+    if isinstance(match, str):
+        return match in text
+    if isinstance(match, re.Pattern):
+        return bool(match.search(text))
+    # Iterable[str|Pattern]
+    for m in match:
+        if isinstance(m, str) and m in text:
+            return True
+        if isinstance(m, re.Pattern) and m.search(text):
+            return True
+    return False
+
+
+def _repair_text(text: str) -> str:
+    """
+    Attempt to repair common mojibake patterns seen in OCR pipelines.
+    Keep the original text when repair does not improve quality.
+    """
+    if not text:
+        return text
+    candidates = [text]
+    # common mojibake path: utf-8 bytes decoded as latin-1/cp1252
+    for enc in ("latin1", "cp1252"):
+        try:
+            candidates.append(text.encode(enc).decode("utf-8"))
+        except Exception:
+            pass
+    # common mojibake path: utf-8 bytes decoded as gbk
+    try:
+        candidates.append(text.encode("gbk", errors="ignore").decode("utf-8", errors="ignore"))
+    except Exception:
+        pass
+    return max(candidates, key=_text_quality)
+
+
+def _text_quality(text: str) -> int:
+    # Higher score means "looks like meaningful OCR text".
+    score = 0
+    for ch in text:
+        if "\u4e00" <= ch <= "\u9fff":  # CJK
+            score += 3
+        elif ch.isalnum():
+            score += 2
+        elif ch in " +-/:%().,，。！？!?:_#[]":
+            score += 1
+        elif ch == "�":  # replacement char
+            score -= 4
+        else:
+            score -= 1
+    return score
+
+
+def _normalize_for_compare(text: str) -> str:
+    if not text:
+        return ""
+    chars = []
+    for ch in text:
+        if ("\u4e00" <= ch <= "\u9fff") or ch.isalnum():
+            chars.append(ch)
+    return "".join(chars).lower()
+
+
+def _match_whitelist(text: str, whitelist: List[str], threshold: float) -> Optional[str]:
+    src = _normalize_for_compare(text)
+    if not src:
+        return None
+
+    best_term: Optional[str] = None
+    best_score = 0.0
+    for term in whitelist:
+        target = _normalize_for_compare(term)
+        if not target:
+            continue
+
+        if src == target or (len(target) >= 2 and target in src) or (len(src) >= 2 and src in target):
+            return term
+
+        score = SequenceMatcher(None, src, target).ratio()
+        if score > best_score:
+            best_score = score
+            best_term = term
+    if best_term is not None and best_score >= threshold:
+        return best_term
+    return None
+
+
+def _pick_cjk_font(size: int):
+    candidates = [
+        r"C:\Windows\Fonts\msyh.ttc",
+        r"C:\Windows\Fonts\msyhbd.ttc",
+        r"C:\Windows\Fonts\simhei.ttf",
+        r"C:\Windows\Fonts\simsun.ttc",
+    ]
+    for path in candidates:
+        if os.path.exists(path):
+            try:
+                return ImageFont.truetype(path, size=size)
+            except Exception:
+                pass
+    return ImageFont.load_default()
+

--- a/src/ocr_helper_tool/okww_adapter.py
+++ b/src/ocr_helper_tool/okww_adapter.py
@@ -1,21 +1,14 @@
 from __future__ import annotations
 
-import os
 import re
-import time
-import json
 from dataclasses import dataclass
 from difflib import SequenceMatcher
-from pathlib import Path
-from typing import Any, Iterable, List, Optional, Pattern, Union
-
-import cv2
-from PIL import Image, ImageDraw, ImageFont
+from typing import Iterable, List, Optional, Pattern, Union
 
 from ok import Box as OKBox
 
 from .adapters import create_ocr_adapter
-from .geometry import pixel_box_to_rel
+from .artifacts import make_timestamp_image_path, write_annotated_image, write_raw_frame, write_results_json
 from .interfaces import Box, OCRText
 
 MatchType = Union[str, Pattern[str], Iterable[Union[str, Pattern[str]]]]
@@ -92,18 +85,12 @@ class OKWWOCRHelper:
         if frame_bgr is None:
             return [], ""
 
-        # Persist the frame to disk (adapters use image_path).
-        Path(screenshot_dir).mkdir(parents=True, exist_ok=True)
-        ts = int(time.time() * 1000)
-        # Keep filename minimal for quick sorting: timestamp only.
-        image_path = os.path.join(screenshot_dir, f"{ts}.png")
-        cv2.imwrite(image_path, frame_bgr)
-
         helper_region: Optional[Box] = None
         if region is not None:
             helper_region = Box(int(region.x), int(region.y), int(region.x + region.width), int(region.y + region.height))
 
-        results: List[OCRText] = self.adapter.recognize(image_path, helper_region)
+        # In-memory OCR by default; avoid disk IO in high-frequency loops.
+        results: List[OCRText] = self.adapter.recognize(frame_bgr, helper_region)
         fixed_results: List[OCRText] = []
         for item in results:
             fixed_text, fixed_confidence = self._normalize_and_whitelist(item.text, item.confidence)
@@ -115,10 +102,13 @@ class OKWWOCRHelper:
                     font_size=item.font_size,
                 )
             )
+        image_path = ""
         should_save_artifacts = self.config.save_artifacts_on_verbose if save_artifacts is None else save_artifacts
         if should_save_artifacts:
-            self._write_annotated_image(image_path, fixed_results)
-            self._write_results_json(image_path, fixed_results, frame_bgr.shape[1], frame_bgr.shape[0])
+            image_path = make_timestamp_image_path(screenshot_dir, ".png")
+            write_raw_frame(frame_bgr, image_path)
+            write_annotated_image(image_path, fixed_results)
+            write_results_json(image_path, fixed_results, frame_bgr.shape[1], frame_bgr.shape[0], self.engine_name)
         return fixed_results, image_path
 
     def _normalize_and_whitelist(self, text: str, confidence: float) -> tuple[str, float]:
@@ -129,49 +119,6 @@ class OKWWOCRHelper:
             boosted = max(float(confidence), float(self.config.whitelist_confidence_floor))
             return matched, boosted
         return repaired, float(confidence)
-
-    def _write_annotated_image(self, raw_path: str, results: List[OCRText]) -> str:
-        img = Image.open(raw_path).convert("RGB")
-        draw = ImageDraw.Draw(img)
-        font = _pick_cjk_font(16)
-        for item in results:
-            b = item.box.normalized()
-            draw.rectangle((b.x1, b.y1, b.x2, b.y2), outline=(0, 80, 255), width=2)
-            label = f"{item.text} | {item.confidence:.2f}"
-            tx, ty = b.x1 + 2, max(2, b.y1 - 20)
-            draw.rectangle((tx - 1, ty - 1, tx + len(label) * 9, ty + 18), fill=(20, 20, 20))
-            draw.text((tx, ty), label, fill=(255, 255, 0), font=font)
-        out = raw_path.replace(".png", "_annotated.png")
-        img.save(out)
-        return out
-
-    def _write_results_json(self, raw_path: str, results: List[OCRText], frame_w: int, frame_h: int) -> str:
-        payload = {
-            "engine": self.engine_name,
-            "frame_size": {"width": frame_w, "height": frame_h},
-            "count": len(results),
-            "items": [],
-        }
-        for item in results:
-            b = item.box.normalized()
-            rel = pixel_box_to_rel(b, frame_w, frame_h).normalized()
-            payload["items"].append(
-                {
-                    "text": item.text,
-                    "confidence": round(float(item.confidence), 6),
-                    "pixel_box": {"x1": b.x1, "y1": b.y1, "x2": b.x2, "y2": b.y2},
-                    "relative_box": {
-                        "x1": round(rel.x1, 6),
-                        "y1": round(rel.y1, 6),
-                        "x2": round(rel.x2, 6),
-                        "y2": round(rel.y2, 6),
-                    },
-                }
-            )
-        out = raw_path.replace(".png", "_results.json")
-        with open(out, "w", encoding="utf-8") as f:
-            json.dump(payload, f, ensure_ascii=False, indent=2)
-        return out
 
 
 def _match_text(text: str, match: MatchType) -> bool:
@@ -261,18 +208,4 @@ def _match_whitelist(text: str, whitelist: List[str], threshold: float) -> Optio
     return None
 
 
-def _pick_cjk_font(size: int):
-    candidates = [
-        r"C:\Windows\Fonts\msyh.ttc",
-        r"C:\Windows\Fonts\msyhbd.ttc",
-        r"C:\Windows\Fonts\simhei.ttf",
-        r"C:\Windows\Fonts\simsun.ttc",
-    ]
-    for path in candidates:
-        if os.path.exists(path):
-            try:
-                return ImageFont.truetype(path, size=size)
-            except Exception:
-                pass
-    return ImageFont.load_default()
 

--- a/src/ocr_helper_tool/okww_adapter.py
+++ b/src/ocr_helper_tool/okww_adapter.py
@@ -10,6 +10,7 @@ from ok import Box as OKBox
 from .adapters import create_ocr_adapter
 from .artifacts import make_timestamp_image_path, write_annotated_frame, write_results_json
 from .interfaces import Box, OCRText
+from .text_utils import normalize_text_for_compare
 
 MatchType = Union[str, Pattern[str], Iterable[Union[str, Pattern[str]]]]
 
@@ -206,18 +207,8 @@ def _text_quality(text: str) -> int:
     return score
 
 
-def _normalize_for_compare(text: str) -> str:
-    if not text:
-        return ""
-    chars = []
-    for ch in text:
-        if ("\u4e00" <= ch <= "\u9fff") or ch.isalnum():
-            chars.append(ch)
-    return "".join(chars).lower()
-
-
 def _match_whitelist_detail(text: str, whitelist: List[str], threshold: float) -> tuple[Optional[str], float, bool]:
-    src = _normalize_for_compare(text)
+    src = normalize_text_for_compare(text)
     if not src:
         return None, 0.0, False
 
@@ -225,7 +216,7 @@ def _match_whitelist_detail(text: str, whitelist: List[str], threshold: float) -
     best_score = 0.0
     best_exact = False
     for term in whitelist:
-        target = _normalize_for_compare(term)
+        target = normalize_text_for_compare(term)
         if not target:
             continue
 
@@ -249,11 +240,11 @@ def _dedupe_results(results: List[OCRText], iou_threshold: float) -> List[OCRTex
     ordered = sorted(results, key=lambda x: float(x.confidence), reverse=True)
     kept: List[OCRText] = []
     for cand in ordered:
-        c_text = _normalize_for_compare(cand.text)
+        c_text = normalize_text_for_compare(cand.text)
         c_box = cand.box.normalized()
         drop = False
         for exist in kept:
-            if _normalize_for_compare(exist.text) != c_text:
+            if normalize_text_for_compare(exist.text) != c_text:
                 continue
             e_box = exist.box.normalized()
             if _box_iou(c_box, e_box) >= thr or _box_contains(e_box, c_box):
@@ -269,11 +260,11 @@ def _merge_results(primary: List[OCRText], secondary: List[OCRText]) -> List[OCR
         return primary
     merged = list(primary)
     for cand in secondary:
-        cand_text = _normalize_for_compare(cand.text)
+        cand_text = normalize_text_for_compare(cand.text)
         cand_box = cand.box.normalized()
         replaced = False
         for idx, exist in enumerate(merged):
-            if _normalize_for_compare(exist.text) != cand_text:
+            if normalize_text_for_compare(exist.text) != cand_text:
                 continue
             overlap = _box_iou(exist.box.normalized(), cand_box)
             if overlap >= 0.4 and cand.confidence > exist.confidence:

--- a/src/ocr_helper_tool/pyside_canvas.py
+++ b/src/ocr_helper_tool/pyside_canvas.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+from PySide6.QtCore import QPoint, QRect, Qt, Signal
+from PySide6.QtGui import QBrush, QColor, QImage, QPainter, QPen, QPixmap
+from PySide6.QtWidgets import QWidget
+
+from .geometry import RelBox, pixel_box_to_rel
+from .interfaces import Box, OCRText
+
+
+@dataclass(frozen=True)
+class CanvasItem:
+    text: str
+    box: Box
+    confidence: float
+
+
+class OCRCanvas(QWidget):
+    """
+    A lightweight, embeddable canvas widget for OCR debugging:
+    - show an image
+    - overlay OCR boxes
+    - allow drag-select region (emits relative coordinates)
+    """
+
+    selectionChanged = Signal(object)  # RelBox
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.setMouseTracking(True)
+        self._pixmap: Optional[QPixmap] = None
+        self._image_size: Tuple[int, int] = (0, 0)
+        self._items: List[CanvasItem] = []
+        self._drag_start: Optional[QPoint] = None
+        self._drag_end: Optional[QPoint] = None
+
+    def set_image_from_path(self, path: str) -> None:
+        pm = QPixmap(path)
+        self._pixmap = pm if not pm.isNull() else None
+        if self._pixmap is not None:
+            self._image_size = (self._pixmap.width(), self._pixmap.height())
+        else:
+            self._image_size = (0, 0)
+        self._items = []
+        self._drag_start = None
+        self._drag_end = None
+        self.update()
+
+    def set_image_from_bgr(self, frame_bgr) -> None:
+        # frame_bgr: numpy array HxWx3 (BGR)
+        import numpy as np
+
+        if frame_bgr is None:
+            self._pixmap = None
+            self._image_size = (0, 0)
+            self.update()
+            return
+        if not isinstance(frame_bgr, np.ndarray) or frame_bgr.ndim != 3:
+            raise ValueError("frame_bgr must be a HxWx3 numpy array")
+        h, w, _c = frame_bgr.shape
+        rgb = frame_bgr[:, :, ::-1].copy()
+        qimg = QImage(rgb.data, w, h, 3 * w, QImage.Format_RGB888)
+        self._pixmap = QPixmap.fromImage(qimg)
+        self._image_size = (w, h)
+        self.update()
+
+    def set_ocr_results(self, results: List[OCRText]) -> None:
+        self._items = [CanvasItem(r.text, r.box.normalized(), r.confidence) for r in results]
+        self.update()
+
+    def clear_overlays(self) -> None:
+        self._items = []
+        self._drag_start = None
+        self._drag_end = None
+        self.update()
+
+    def _target_rect(self) -> QRect:
+        """Compute the letterboxed rect where pixmap is drawn."""
+        if self._pixmap is None:
+            return QRect(0, 0, 0, 0)
+        iw, ih = self._image_size
+        if iw <= 0 or ih <= 0:
+            return QRect(0, 0, 0, 0)
+        ww, wh = max(1, self.width()), max(1, self.height())
+        scale = min(ww / iw, wh / ih)
+        dw, dh = int(iw * scale), int(ih * scale)
+        ox = (ww - dw) // 2
+        oy = (wh - dh) // 2
+        return QRect(ox, oy, dw, dh)
+
+    def _to_canvas(self, p: QPoint) -> Optional[Tuple[int, int]]:
+        """Map widget coords to image pixel coords."""
+        if self._pixmap is None:
+            return None
+        rect = self._target_rect()
+        if rect.width() <= 0 or rect.height() <= 0:
+            return None
+        if not rect.contains(p):
+            return None
+        iw, ih = self._image_size
+        x = p.x() - rect.x()
+        y = p.y() - rect.y()
+        px = int(round(x * (iw / rect.width())))
+        py = int(round(y * (ih / rect.height())))
+        px = max(0, min(iw - 1, px))
+        py = max(0, min(ih - 1, py))
+        return px, py
+
+    def _box_to_widget_rect(self, box: Box) -> Optional[QRect]:
+        if self._pixmap is None:
+            return None
+        rect = self._target_rect()
+        iw, ih = self._image_size
+        if iw <= 0 or ih <= 0:
+            return None
+        b = box.normalized()
+        sx = rect.width() / iw
+        sy = rect.height() / ih
+        x1 = int(rect.x() + b.x1 * sx)
+        y1 = int(rect.y() + b.y1 * sy)
+        x2 = int(rect.x() + b.x2 * sx)
+        y2 = int(rect.y() + b.y2 * sy)
+        return QRect(min(x1, x2), min(y1, y2), abs(x2 - x1), abs(y2 - y1))
+
+    def paintEvent(self, _event) -> None:
+        p = QPainter(self)
+        p.fillRect(self.rect(), QColor(20, 20, 20))
+
+        if self._pixmap is None:
+            p.end()
+            return
+
+        target = self._target_rect()
+        p.drawPixmap(target, self._pixmap)
+
+        # OCR overlays
+        pen = QPen(QColor(255, 77, 79, 220))
+        pen.setWidth(2)
+        p.setPen(pen)
+        p.setBrush(QBrush(QColor(255, 77, 79, 50)))
+        for item in self._items:
+            r = self._box_to_widget_rect(item.box)
+            if r is None:
+                continue
+            p.drawRect(r)
+            label = f"{item.text}  ({item.confidence:.2f})"
+            p.setPen(QPen(QColor(255, 224, 138, 230)))
+            p.drawText(r.x() + 2, max(12, r.y() - 4), label)
+            p.setPen(pen)
+
+        # Selection overlay
+        if self._drag_start is not None and self._drag_end is not None:
+            p.setPen(QPen(QColor(0, 255, 136, 230), 2, Qt.DashLine))
+            p.setBrush(QBrush(QColor(0, 255, 136, 40)))
+            sel = QRect(self._drag_start, self._drag_end).normalized()
+            p.drawRect(sel)
+
+        p.end()
+
+    def mousePressEvent(self, event) -> None:
+        if event.button() != Qt.LeftButton:
+            return
+        self._drag_start = event.position().toPoint()
+        self._drag_end = self._drag_start
+        self.update()
+
+    def mouseMoveEvent(self, event) -> None:
+        if self._drag_start is None:
+            return
+        self._drag_end = event.position().toPoint()
+        self.update()
+
+    def mouseReleaseEvent(self, event) -> None:
+        if event.button() != Qt.LeftButton:
+            return
+        if self._drag_start is None:
+            return
+        self._drag_end = event.position().toPoint()
+
+        p1 = self._to_canvas(self._drag_start)
+        p2 = self._to_canvas(self._drag_end)
+        self._drag_start = None
+        self._drag_end = None
+        self.update()
+        if p1 is None or p2 is None:
+            return
+        (x1, y1), (x2, y2) = p1, p2
+        box = Box(x1, y1, x2, y2).normalized()
+        iw, ih = self._image_size
+        rel = pixel_box_to_rel(box, iw, ih).normalized()
+        self.selectionChanged.emit(rel)
+

--- a/src/ocr_helper_tool/text_utils.py
+++ b/src/ocr_helper_tool/text_utils.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+
+def normalize_text_for_compare(text: str) -> str:
+    if not text:
+        return ""
+    chars = []
+    for ch in text:
+        if ("\u4e00" <= ch <= "\u9fff") or ch.isalnum():
+            chars.append(ch)
+    return "".join(chars).lower()
+


### PR DESCRIPTION
﻿## 变更目的
本次贡献仅替换 OCR 工具箱，目标是获得更可靠的 OCR 识别能力与更好的可调试性。

## 变更范围
- 新增/完善 `src/ocr_helper_tool/` 工具箱模块（适配器、会话、几何转换、画布、CLI）
- 修复工具箱评审问题：
  - OCR 适配器支持内存图像输入（减少高频 OCR 落盘）
  - 产物命名改为健壮路径拼接（不再依赖 `.replace('.png', ...)`）
  - 抽取公共产物/字体工具，消除重复代码
- 不修改任务运行中的 OCR 调用链路（不接管 `BaseWWTask.ocr` 运行时逻辑）
- 不调整全局默认 OCR 后端配置（保持项目现状）

## 价值说明
同图对比下，工具箱方案在全图识别覆盖与关键词命中上更稳定，便于后续在与维护者确认后逐步推进运行时重构。

## 复现方式
`python -m src.ocr_helper_tool.cli --image <image_path> --engine auto`
输出：`<timestamp>.png / <timestamp>_annotated.png / <timestamp>_results.json`
