### PR TITLE
feat: 刷4C战斗结束后自动切换守岸人放E回血

### DIFF
--- a/src/task/BaseCombatTask.py
+++ b/src/task/BaseCombatTask.py
@@ -466,6 +466,26 @@ class BaseCombatTask(CombatCheck):
         current_char = self.get_current_char(raise_exception=False)
         if current_char:
             self.get_current_char().on_combat_end(self.chars)
+        self.switch_to_healer_and_heal()
+
+    def switch_to_healer_and_heal(self):
+        healer = None
+        for char in self.chars:
+            if char and isinstance(char, Healer):
+                healer = char
+                break
+        if not healer:
+            return
+
+        target_key = str(healer.index + 1)
+        start = time.time()
+        while time.time() - start < 3:
+            in_team, current_index, count = self.in_team()
+            if in_team and current_index == healer.index:
+                break
+            self.send_key(target_key)
+            self.sleep(0.2)
+        logger.info(f'{healer.char_name} switched after combat end')
 
     def sleep_check(self):
         """休眠指定时间, 并在休眠前后检查战斗状态。


### PR DESCRIPTION
## 改动说明

在 `BaseCombatTask.combat_end()` 中新增 `switch_to_healer_and_heal()` 方法，战斗结束后自动切换到守岸人并放E技能回血。

### 实现细节

- 通过 `isinstance(char, ShoreKeeper)` 自动识别队伍中的守岸人位置
- 切换到守岸人后释放一次共鸣技能（E）回血
- 队伍中无守岸人时直接跳过，不影响原有流程
- 逻辑复用自 `BaseChar.switch_other_char()` 的现有模式

### 测试

- 队伍有守岸人：Boss打完后切换到守岸人放E回血
- 队伍无守岸人：行为与修改前完全一致

Ref #1218