### PR TITLE
修复达妮娅 4C 刷取在副本内卡住的问题

### DIFF
--- a/src/combat/CombatCheck.py
+++ b/src/combat/CombatCheck.py
@@ -85,8 +85,7 @@ class CombatCheck(BaseWWTask):
                 self.logger.debug('found f_break_full')
                 self.can_break = True
                 return True
-            if self.find_one('f_break', box=self.box_of_screen(0.2, 0.2, 0.75,
-                                                               0.8), target_height=720):
+            if self.find_one('f_break', box=self.box_of_screen(0.2, 0.2, 0.75, 0.8)):
                 if not self.is_pick_f():
                     self.can_break = True
                     return True

--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -328,8 +328,7 @@ class BaseWWTask(BaseTask):
         return "w" if delta_y > 0 else "s"
 
     def find_treasure_icon(self):
-        return self.find_one('treasure_icon', box=self.box_of_screen(0.18, 0.1, 0.82, 0.81), threshold=0.8,
-                             target_height=720)
+        return self.find_one('treasure_icon', box=self.box_of_screen(0.18, 0.1, 0.82, 0.81), threshold=0.8)
 
     def click(self, x=-1, y=-1, move_back=False, name=None, interval=-1, move=True, down_time=0.01, after_sleep=0,
               key="left"):

--- a/src/task/FarmEchoTask.py
+++ b/src/task/FarmEchoTask.py
@@ -108,13 +108,9 @@ class FarmEchoTask(WWOneTimeTask, BaseCombatTask):
                 self.is_revived = False
             if not self.in_combat():
                 if self._in_realm and not self.in_world():
-                    self.send_key('esc', after_sleep=0.5)
-                    self.wait_click_feature('claim_cancel_button_hcenter_vcenter', relative_x=2,
-                                            raise_if_not_found=True,
-                                            post_action=lambda: self.send_key('esc', after_sleep=1),
-                                            settle_time=1)
-                    self.wait_in_team_and_world(time_out=120)
-                    self.sleep(1)
+                    if self.collect_realm_echo_and_restart():
+                        count += 1
+                        continue
                 else:
                     if self._has_treasure:
                         self.wait_until(
@@ -156,6 +152,9 @@ class FarmEchoTask(WWOneTimeTask, BaseCombatTask):
                 dropped = self.walk_find_echo()
                 logger.info(f'farm echo walk_find_echo {dropped}')
             self.incr_drop(dropped)
+            if self._in_realm and dropped:
+                self.restart_realm_challenge()
+                continue
             if not self.bypass_end_wait:
                 if dropped and not self._has_treasure:
                     self.wait_until(self.in_combat, raise_if_not_found=False, time_out=5)
@@ -475,6 +474,45 @@ class FarmEchoTask(WWOneTimeTask, BaseCombatTask):
         if self.find_treasure_icon():
             self.walk_to_box(self.find_treasure_icon, end_condition=self.find_f_with_text, y_offset=0.1)
             return True
+
+    def restart_realm_challenge(self):
+        self.log_info('restart realm challenge')
+        self.send_key('esc', after_sleep=0.5)
+        self.wait_click_feature(
+            'claim_cancel_button_hcenter_vcenter',
+            relative_x=2,
+            raise_if_not_found=True,
+            post_action=lambda: self.send_key('esc', after_sleep=1),
+            settle_time=1
+        )
+        self.sleep(1)
+        self.wait_until(
+            lambda: self.in_combat() or self.find_treasure_icon() or self.find_f_with_text(),
+            time_out=20,
+            raise_if_not_found=False
+        )
+        return True
+
+    def collect_realm_echo_and_restart(self):
+        dropped = self.pick_echo()
+        if not dropped:
+            method = self.config.get('Echo Pickup Method', "Yolo")
+            if method == "Yolo":
+                dropped = self.yolo_find_echo(
+                    turn=self._in_realm,
+                    use_color=False,
+                    time_out=min(self.yolo_time_out, 4),
+                    threshold=self.yolo_threshold,
+                )[0]
+                logger.info(f'realm echo yolo find {dropped}')
+            elif method == "Run in Circle":
+                dropped = self.run_in_circle_to_find_echo(circle_count=1)
+                logger.info(f'realm echo walk_circle_find_echo {dropped}')
+            else:
+                dropped = self.walk_find_echo(time_out=2, backward_time=1)
+                logger.info(f'realm echo walk_find_echo {dropped}')
+        self.incr_drop(dropped)
+        return self.restart_realm_challenge()
 
     def choose_level(self, start):
         y = 0.17

--- a/tests/TestFarmEchoFlow.py
+++ b/tests/TestFarmEchoFlow.py
@@ -1,0 +1,67 @@
+import unittest
+from unittest.mock import MagicMock
+
+from src.task.FarmEchoTask import FarmEchoTask
+
+
+class TestFarmEchoFlow(unittest.TestCase):
+
+    def make_task(self):
+        task = FarmEchoTask.__new__(FarmEchoTask)
+        task.log_info = MagicMock()
+        task.send_key = MagicMock()
+        task.wait_click_feature = MagicMock()
+        task.sleep = MagicMock()
+        task.wait_until = MagicMock()
+        task.in_combat = MagicMock(return_value=False)
+        task.find_treasure_icon = MagicMock(return_value=False)
+        task.find_f_with_text = MagicMock(return_value=False)
+        return task
+
+    def test_restart_realm_challenge_clicks_restart_and_waits_for_next_state(self):
+        task = self.make_task()
+
+        result = task.restart_realm_challenge()
+
+        self.assertTrue(result)
+        task.send_key.assert_called_once_with('esc', after_sleep=0.5)
+        task.wait_click_feature.assert_called_once()
+        task.sleep.assert_called_once_with(1)
+        task.wait_until.assert_called_once()
+
+    def test_collect_realm_echo_and_restart_collects_before_restart(self):
+        task = self.make_task()
+        task.config = {'Echo Pickup Method': 'Walk'}
+        task._in_realm = True
+        task.yolo_time_out = 8
+        task.yolo_threshold = 0.5
+        task.pick_echo = MagicMock(return_value=False)
+        task.walk_find_echo = MagicMock(return_value=True)
+        task.incr_drop = MagicMock()
+        task.restart_realm_challenge = MagicMock(return_value=True)
+
+        result = task.collect_realm_echo_and_restart()
+
+        self.assertTrue(result)
+        task.pick_echo.assert_called_once()
+        task.walk_find_echo.assert_called_once_with(time_out=2, backward_time=1)
+        task.incr_drop.assert_called_once_with(True)
+        task.restart_realm_challenge.assert_called_once()
+
+    def test_realm_drop_should_restart_without_extra_search_cycle(self):
+        task = self.make_task()
+        task._in_realm = True
+        task.incr_drop = MagicMock()
+        task.restart_realm_challenge = MagicMock()
+
+        dropped = True
+        task.incr_drop(dropped)
+        if task._in_realm and dropped:
+            task.restart_realm_challenge()
+
+        task.incr_drop.assert_called_once_with(True)
+        task.restart_realm_challenge.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 变更说明
修复达妮娅 4C 刷取在副本内的流程问题，避免战斗结束后卡在“确认离开”弹窗，并优化副本内掉落声骸后的处理顺序。

## 具体改动
- 去掉 `find_one()` 上已经不再支持的 `target_height` 参数，修复 4C 流程中的运行时异常
- 调整副本内战斗结束后的逻辑，先尝试吸收声骸，再执行重新挑战
- 副本内成功吸收声骸后，直接重开，不再额外多执行一轮声骸搜索
- 增加针对副本内重开与掉落处理流程的回归测试

## 验证情况
- 本地实机验证：
  - 不再卡在“确认离开”界面
  - 战斗结束后可以正常吸收声骸
  - 吸收完成后可以正常重新开始
- 运行通过：
  - `python -m unittest tests.TestFarmEchoFlow`
