### PR TITLE
fix:在自动战斗界面增加排轴功能

### DIFF
--- a/.github/workflows/ai_code_review.yml
+++ b/.github/workflows/ai_code_review.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: AI Code Review
+        continue-on-error: true
         uses: ok-oldking/ai-codereviewer@main
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/char/CustomRotation.py
+++ b/src/char/CustomRotation.py
@@ -1,0 +1,255 @@
+import time
+from dataclasses import dataclass
+
+
+class CustomRotationConfigError(ValueError):
+    pass
+
+
+@dataclass
+class RotationAction:
+    line_no: int
+    raw: str
+    name: str
+    value: str | None = None
+    interval: float | None = None
+
+
+class CustomRotation:
+    DEFAULT_TAP_INTERVAL = 0.1
+    DEFAULT_HEAVY_DURATION = 0.6
+    DEFAULT_KEY_AFTER_SLEEP = 0.01
+
+    def __init__(self, task):
+        self.task = task
+        self._script = None
+        self._actions = []
+        self._index = 0
+
+    def load(self, script, reset=False):
+        script = script or ''
+        if script != self._script:
+            self._script = script
+            self._actions = self._parse(script)
+            self._index = 0
+        elif reset:
+            self._index = 0
+        if not self._actions:
+            raise CustomRotationConfigError('自定义技能轴没有有效动作')
+
+    def perform_next(self):
+        if not self._actions:
+            raise CustomRotationConfigError('自定义技能轴没有有效动作')
+        action = self._actions[self._index]
+        self._index = (self._index + 1) % len(self._actions)
+        self.task.log_info(f'自定义技能轴 第{action.line_no}行: {action.raw}')
+        self._perform(action)
+
+    def _perform(self, action):
+        current_char = self.task.get_current_char(raise_exception=True)
+        name = action.name
+        if name == 'switch':
+            if action.value is None:
+                current_char.switch_next_char()
+            else:
+                self._switch_to(int(action.value))
+        elif name == 'tap':
+            interval = self.DEFAULT_TAP_INTERVAL if action.interval is None else action.interval
+            self._tap(current_char, int(action.value), interval)
+        elif name == 'attack':
+            interval = self.DEFAULT_TAP_INTERVAL if action.interval is None else action.interval
+            current_char.continues_normal_attack(float(action.value), interval=interval)
+        elif name == 'heavy':
+            current_char.heavy_attack(float(action.value or self.DEFAULT_HEAVY_DURATION))
+        elif name == 'sleep':
+            current_char.sleep(float(action.value))
+        elif name == 'resonance':
+            current_char.click_resonance()
+        elif name == 'liberation':
+            self._click_liberation(current_char)
+        elif name == 'echo':
+            current_char.click_echo()
+        elif name == 'dodge':
+            self._send_config_key('Dodge Key', action.value)
+        elif name == 'jump':
+            self.task.jump(after_sleep=self._optional_float(action.value, self.DEFAULT_KEY_AFTER_SLEEP))
+        else:
+            raise CustomRotationConfigError(f'第{action.line_no}行未知动作: {action.raw}')
+
+    def _tap(self, current_char, count, interval):
+        for _ in range(count):
+            current_char.normal_attack()
+            current_char.sleep(interval)
+
+    def _click_liberation(self, current_char):
+        old_use_liberation = self.task.use_liberation
+        self.task.use_liberation = True
+        try:
+            current_char.click_liberation()
+        finally:
+            self.task.use_liberation = old_use_liberation
+
+    def _send_config_key(self, key_name, after_sleep):
+        key = self.task.key_config.get(key_name)
+        if not key:
+            raise CustomRotationConfigError(f'未配置按键: {key_name}')
+        self.task.send_key(key, after_sleep=self._optional_float(after_sleep, self.DEFAULT_KEY_AFTER_SLEEP))
+
+    def _switch_to(self, position):
+        target_index = position - 1
+        in_team, current_index, count = self.task.in_team()
+        if not in_team:
+            self.task.raise_not_in_combat('custom rotation switch failed: not in team')
+        if position < 1 or position > count:
+            raise CustomRotationConfigError(f'切换目标不存在: switch:{position}')
+        current_char = self.task.get_current_char(raise_exception=True)
+        if current_char.index == target_index:
+            return
+        switch_to = self.task.chars[target_index]
+        if switch_to is None:
+            raise CustomRotationConfigError(f'切换目标未识别: switch:{position}')
+
+        has_intro = current_char.get_current_con() == 1
+        start = time.time()
+        last_click = 0
+        while True:
+            self.task.check_combat()
+            now = time.time()
+            in_team, current_index, _ = self.task.in_team()
+            if in_team and current_index == target_index:
+                current_char.switch_out()
+                for char in self.task.chars:
+                    if char:
+                        char.is_current_char = (char.index == current_index)
+                switch_to.has_intro = has_intro
+                if has_intro:
+                    current_time = time.time()
+                    self.task.add_freeze_duration(current_time, switch_to.intro_motion_freeze_duration, -100)
+                    current_char.last_outro_time = current_time
+                return
+            if now - start > getattr(self.task, 'switch_char_time_out', 5):
+                self.task.raise_not_in_combat(f'custom rotation switch:{position} timeout')
+            if now - last_click > 0.1:
+                self.task.send_key(str(position))
+                self.task.sleep(0.001)
+                self.task.click()
+                self.task.sleep(0.001)
+                last_click = now
+            self.task.next_frame()
+
+    def _parse(self, script):
+        actions = []
+        for line_no, raw_line in enumerate(script.splitlines(), 1):
+            line = raw_line.split('#', 1)[0].strip()
+            if not line:
+                continue
+            actions.append(self._parse_line(line_no, line))
+        return actions
+
+    def _parse_line(self, line_no, line):
+        command, interval = self._split_interval(line_no, line)
+        name, value = self._split_value(command)
+        name = self._normalize_name(name)
+        self._validate(line_no, line, name, value, interval)
+        return RotationAction(line_no=line_no, raw=line, name=name, value=value, interval=interval)
+
+    def _split_interval(self, line_no, line):
+        parts = line.split('@', 1)
+        if len(parts) == 1:
+            return parts[0].strip(), None
+        try:
+            return parts[0].strip(), float(parts[1].strip())
+        except ValueError as exc:
+            raise CustomRotationConfigError(f'第{line_no}行间隔不是数字: {line}') from exc
+
+    def _split_value(self, command):
+        parts = command.split(':', 1)
+        if len(parts) == 1:
+            return parts[0].strip().lower(), None
+        return parts[0].strip().lower(), parts[1].strip()
+
+    def _normalize_name(self, name):
+        aliases = {
+            'click': 'tap',
+            'na': 'tap',
+            'normal': 'tap',
+            'normal_attack': 'tap',
+            'res': 'resonance',
+            'skill': 'resonance',
+            'e': 'resonance',
+            'lib': 'liberation',
+            'ult': 'liberation',
+            'r': 'liberation',
+            'q': 'echo',
+            'swap': 'switch',
+            'wait': 'sleep',
+            'dash': 'dodge',
+            '切人': 'switch',
+            '普攻': 'tap',
+            '点击': 'tap',
+            '连续普攻': 'attack',
+            '重击': 'heavy',
+            '等待': 'sleep',
+            '共鸣技能': 'resonance',
+            '技能': 'resonance',
+            '共鸣解放': 'liberation',
+            '大招': 'liberation',
+            '声骸': 'echo',
+            '闪避': 'dodge',
+            '跳跃': 'jump',
+        }
+        return aliases.get(name, name)
+
+    def _validate(self, line_no, raw, name, value, interval):
+        if name not in {
+            'switch', 'tap', 'attack', 'heavy', 'sleep',
+            'resonance', 'liberation', 'echo', 'dodge', 'jump',
+        }:
+            raise CustomRotationConfigError(f'第{line_no}行未知动作: {raw}')
+        if interval is not None and interval < 0:
+            raise CustomRotationConfigError(f'第{line_no}行动作间隔不能小于0: {raw}')
+        if interval is not None and name not in {'tap', 'attack'}:
+            raise CustomRotationConfigError(f'第{line_no}行只有 tap/attack 支持 @间隔: {raw}')
+        if name == 'switch':
+            if value is not None and not self._is_int_in_range(value, 1, 3):
+                raise CustomRotationConfigError(f'第{line_no}行 switch 只能是 1/2/3: {raw}')
+        elif name == 'tap':
+            if not self._is_positive_int(value):
+                raise CustomRotationConfigError(f'第{line_no}行 tap 需要正整数次数: {raw}')
+        elif name in {'attack', 'sleep'}:
+            if not self._is_non_negative_float(value):
+                raise CustomRotationConfigError(f'第{line_no}行 {name} 需要秒数: {raw}')
+        elif name == 'heavy':
+            if value is not None and not self._is_non_negative_float(value):
+                raise CustomRotationConfigError(f'第{line_no}行 heavy 需要秒数: {raw}')
+        elif name in {'dodge', 'jump'}:
+            if value is not None and not self._is_non_negative_float(value):
+                raise CustomRotationConfigError(f'第{line_no}行 {name} 需要秒数: {raw}')
+        elif value is not None:
+            raise CustomRotationConfigError(f'第{line_no}行 {name} 不支持参数: {raw}')
+
+    def _optional_float(self, value, default):
+        if value is None:
+            return default
+        return float(value)
+
+    def _is_positive_int(self, value):
+        return self._is_int_in_range(value, 1, 999)
+
+    def _is_int_in_range(self, value, minimum, maximum):
+        if value is None:
+            return False
+        try:
+            parsed = int(value)
+        except ValueError:
+            return False
+        return minimum <= parsed <= maximum
+
+    def _is_non_negative_float(self, value):
+        if value is None:
+            return False
+        try:
+            parsed = float(value)
+        except ValueError:
+            return False
+        return parsed >= 0

--- a/src/task/AutoCombatTask.py
+++ b/src/task/AutoCombatTask.py
@@ -3,10 +3,26 @@ import time
 from qfluentwidgets import FluentIcon
 
 from ok import TriggerTask, Logger
+from src.char.CustomRotation import CustomRotation, CustomRotationConfigError
 from src.scene.WWScene import WWScene
 from src.task.BaseCombatTask import BaseCombatTask, NotInCombatException, CharDeadException
 
 logger = Logger.get_logger(__name__)
+
+CUSTOM_ROTATION_ENABLED = '自定义技能轴'
+CUSTOM_ROTATION_SCRIPT = '自定义技能轴脚本'
+CUSTOM_ROTATION_EXAMPLE = """# 自定义队伍技能轴，每行一个动作，默认示例全部注释，不会执行
+# switch:1 / 切人:1        切到1号位，switch不带数字则使用原来的自动切人
+# tap:3@0.15 / 普攻:3@0.15 普攻点击3次，每次间隔0.15秒
+# attack:0.5@0.1 / 连续普攻:0.5@0.1  连续普攻0.5秒，每次间隔0.1秒
+# resonance / 共鸣技能     共鸣技能
+# liberation / 大招        共鸣解放
+# echo / 声骸              声骸技能
+# heavy:0.6 / 重击:0.6     重击0.6秒
+# dodge:0.1 / 闪避:0.1     闪避后等待0.1秒
+# jump:0.1 / 跳跃:0.1      跳跃后等待0.1秒
+# sleep:1.2 / 等待:1.2     等待1.2秒
+"""
 
 
 class AutoCombatTask(BaseCombatTask, TriggerTask):
@@ -16,19 +32,44 @@ class AutoCombatTask(BaseCombatTask, TriggerTask):
         self.default_config = {'_enabled': True}
         self.trigger_interval = 0.1
         self.name = "Auto Combat"
-        self.description = "Enable auto combat in Abyss, Game World etc"
+        self.description = "自动战斗；展开本卡片可配置自定义队伍技能轴"
+        self.instructions = """自定义技能轴位置：
+在 Auto Combat 卡片中展开配置，打开“自定义技能轴”，然后在“自定义技能轴脚本”里填写队伍轴。
+
+常用写法：
+切人:1
+普攻:3@0.15
+共鸣技能
+等待:0.3
+闪避:0.1
+切人:2
+大招
+声骸
+
+说明：
+每行一个动作，# 开头是注释。
+普攻:3@0.15 表示普攻点 3 次，每次间隔 0.15 秒。
+连续普攻:0.5@0.1 表示连续普攻 0.5 秒，每次间隔 0.1 秒。
+切人:1/2/3 表示指定切到对应队伍位置。
+"""
         self.icon = FluentIcon.CALORIES
         self.last_is_click = False
         self.default_config.update({
             'Auto Target': True,
             'Use Liberation': True,
             'Check Levitator': True,
+            CUSTOM_ROTATION_ENABLED: False,
+            CUSTOM_ROTATION_SCRIPT: CUSTOM_ROTATION_EXAMPLE,
         })
         self.config_description = {
             'Auto Target': 'Turn off to enable auto combat only when manually target enemy using middle click',
             'Use Liberation': 'Do not use Liberation in Open World to Save Time',
             'Check Levitator': 'Toggle the levitator and verify if the character is floating',
+            CUSTOM_ROTATION_ENABLED: '开启后按下方队伍技能轴逐行执行，关闭时使用角色内置自动战斗逻辑',
+            CUSTOM_ROTATION_SCRIPT: '每行一个动作；支持 switch/tap/attack/resonance/liberation/echo/heavy/dodge/jump/sleep，也支持中文别名，# 开头为注释',
         }
+        self.config_type[CUSTOM_ROTATION_SCRIPT] = {'type': 'text_edit'}
+        self.custom_rotation = CustomRotation(self)
         self.op_index = 0
 
     def run(self):
@@ -38,11 +79,24 @@ class AutoCombatTask(BaseCombatTask, TriggerTask):
         self.use_liberation = self.config.get('Use Liberation')
         if not self.use_liberation and not self.in_world():  # 仅大世界生效
             self.use_liberation = True
+        use_custom_rotation = self.config.get(CUSTOM_ROTATION_ENABLED)
+        if use_custom_rotation:
+            try:
+                self.custom_rotation.load(self.config.get(CUSTOM_ROTATION_SCRIPT, ''), reset=True)
+            except CustomRotationConfigError as e:
+                self.log_error(f'自定义技能轴配置错误，已回退到内置自动战斗: {e}')
+                use_custom_rotation = False
         combat_start = time.time()
         while self.in_combat():
             ret = True
             try:
-                self.get_current_char().perform()
+                if use_custom_rotation:
+                    self.custom_rotation.perform_next()
+                else:
+                    self.get_current_char().perform()
+            except CustomRotationConfigError as e:
+                self.log_error(f'自定义技能轴执行错误，已回退到内置自动战斗: {e}')
+                use_custom_rotation = False
             except CharDeadException:
                 self.log_error(f'Characters dead', notify=True)
                 break


### PR DESCRIPTION
## 变更内容

  为 `Auto Combat` 增加自定义队伍技能轴能力，用户可以在打包后的程序界面中直接配置技能释放顺序。

  主要改动：

  - 新增 `CustomRotation` 模块，用于解析并执行用户填写的队伍技能轴脚本
  - 在 `Auto Combat` 配置中新增：
    - `自定义技能轴`
    - `自定义技能轴脚本`
  - 增加 `Instructions` 说明，提示用户入口位置和基础写法
  - 支持中文和英文指令别名，例如：
    - `切人:1` / `switch:1`
    - `普攻:3@0.15` / `tap:3@0.15`
    - `共鸣技能` / `resonance`
    - `大招` / `liberation`
    - `声骸` / `echo`
  - 自定义技能轴配置或执行出错时，会记录错误并回退到原有自动战斗逻辑

  ## 支持的脚本示例

  ```text
  切人:1
  普攻:3@0.15
  共鸣技能
  等待:0.3
  闪避:0.1
  切人:2
  大招
  声骸

  ## 验证

  - 通过 python -m py_compile src/char/CustomRotation.py src/task/AutoCombatTask.py
  - 使用 PyInstaller 生成本地调试包并启动成功
  - 确认打包后配置中出现 自定义技能轴 和 自定义技能轴脚本