### PR TITLE
修复刷4c无铭探索者时脱离战斗后，脚本打开地图找不到图标

### DIFF
--- a/src/task/FarmEchoTask.py
+++ b/src/task/FarmEchoTask.py
@@ -357,6 +357,10 @@ class FarmEchoTask(WWOneTimeTask, BaseCombatTask):
             return
         self.send_key('m', after_sleep=2)
 
+        boss = self.config.get('Boss')
+        if boss == 'Nameless Explorer':
+            self.click(0.06, 0.50, after_sleep=0.5)  # 无铭探索者图标在上层地图，切换到上层
+
         box = self.find_boss_check_mark()
 
         self.log_info(f'teleport_to_nearest_boss {box}')


### PR DESCRIPTION
当boss为无铭探索者时，打开地图默认为下层，增加了一个点击操作以切换到上层地图正确识别boss图标

