### PR TITLE
修复副本/无音区体力任务死亡恢复链路，确保先退本再重入并稳定续跑

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile '.\requirements.in'
 #
-ok-script==1.0.112
+ok-script==1.0.116
     # via -r .\requirements.in
 OpenCC==1.2.0
 onnxocr-ppocrv5==0.0.17

--- a/src/task/BaseCombatTask.py
+++ b/src/task/BaseCombatTask.py
@@ -8,7 +8,6 @@ import numpy as np
 from ok import Logger, Config
 from ok import color_range_to_bound
 from ok import safe_get
-from ok.feature.Box import get_bounding_box
 from src import text_white_color
 from src.char import BaseChar
 from src.char.BaseChar import Priority, dot_color  # noqa
@@ -28,6 +27,11 @@ class NotInCombatException(Exception):
 
 class CharDeadException(NotInCombatException):
     """角色死亡异常。"""
+    pass
+
+
+class CharRevivedException(CharDeadException):
+    """角色已复活，用于中断当前战斗上下文并让任务重新进入。"""
     pass
 
 
@@ -170,47 +174,33 @@ class BaseCombatTask(CombatCheck):
 
     def revive_action(self):
         """角色死亡恢复：关闭弹窗 → 传周本入口 → 传最近传送点回血。"""
-        prev = self.skip_combat_check
-        self.skip_combat_check = True
         try:
-            self.send_key('esc', after_sleep=2)          # ① 关闭复活弹窗
-            self._revive_goto_weekly_entrance()          # ② 传周本锚点
-            self.teleport_to_heal(esc=False)             # ③ 传最近传送点
-        finally:
-            self.skip_combat_check = prev
-        # 这里刻意返回 False，用于中断当前 combat loop（不是“成功/失败”的语义）。
-        # 上层任务会在捕获异常后重建状态（回到大世界/重进副本/继续循环）。
-        return False
+            self.send_key('esc', after_sleep=2)  # ① 关闭复活弹窗
+            self.revive_at_tower_and_heal()
+            logger.info(f'revive_action success')
+            return True
+        except CharRevivedException:
+            logger.info(f'revive_action success')
+            return True
+        except Exception as e:
+            logger.error(f'revive_action failed', e)
+            return False
 
-    def _revive_goto_weekly_entrance(self):
-        """复用周本入口作为复活后的稳定锚点。"""
-        self.ensure_main(time_out=80)
-        gray_book_weekly = self.openF2Book('gray_book_weekly')
-        if not gray_book_weekly:
-            self.log_error('revive: gray_book_weekly not found')
-            return
-        self.click_box(gray_book_weekly, after_sleep=1)
-        btn = self.find_one('boss_proceed', box=self.box_of_screen(0.91, 0.3, 0.95, 0.41), threshold=0.8)
-        if not btn:
-            self.log_error('revive: boss_proceed not found')
-            self.ensure_main(time_out=10)
-            return
-        self.click_box(btn, after_sleep=1)
-        self.wait_click_travel()
-        self.wait_in_team_and_world(time_out=120)
-        self.sleep(1)
+    def revive_at_tower_and_heal(self):
+        """Use the weekly entrance as a stable anchor, then teleport to heal."""
+        self.go_to_tower()
+        self.teleport_to_heal()
 
-    def teleport_to_heal(self, esc=True):
+    def teleport_to_heal(self):
         """传送回城治疗。"""
-        if esc:
-            self.sleep(1)
-            self.info['Death Count'] = self.info.get('Death Count', 0) + 1
-            self.send_key('esc', after_sleep=2)
+        self.ensure_main(time_out=10)
         self.log_info('click m to open the map')
-        self.send_key('m', after_sleep=2)
-
+        start = time.time()
+        while self.in_team_and_world() and time.time() - start < 20:
+            self.send_key('m', after_sleep=2)
+        self.sleep(2)
         teleport = self.find_best_match_in_box(self.box_of_screen(0.1, 0.1, 0.9, 0.9),
-                                               ['map_way_point', 'map_way_point_big'], 0.7)
+                                               ['map_way_point', 'map_way_point_big'], 0.6)
         if not teleport:
             raise RuntimeError(f'Can not find a teleport to heal')
         self.click(teleport, after_sleep=1)
@@ -226,15 +216,27 @@ class BaseCombatTask(CombatCheck):
         self.wait_in_team_and_world(time_out=20)
         self.sleep(2)
 
-    def raise_not_in_combat(self, message, exception_type=None):
+    def raise_not_in_combat(self, message):
         """抛出未在战斗状态的异常。
 
         Args:
             message (str): 异常信息。
             exception_type (Exception, optional): 要抛出的异常类型。默认为 NotInCombatException。
         """
+        exception_type = None
         logger.error(message)
-        if self.reset_to_false(reason=message):
+        if self.wait_feature('revive_confirm_hcenter_vcenter', threshold=0.8, time_out=2):
+            self.log_info('raise_not_in_combat char dead')
+            if self.reset_to_false(reason=message):
+                logger.error(f'reset to false failed: {message}')
+            from src.task.AutoCombatTask import AutoCombatTask
+            if not isinstance(self, AutoCombatTask) and self.revive_action():
+                exception_type = CharRevivedException
+                self.info_set('Revive', 'Success')
+            else:
+                exception_type = CharDeadException
+                self.info_set('Revive', 'Failed')
+        elif self.reset_to_false(reason=message):
             logger.error(f'reset to false failed: {message}')
         if exception_type is None:
             exception_type = NotInCombatException
@@ -372,12 +374,6 @@ class BaseCombatTask(CombatCheck):
         while True:
             if not (isinstance(switch_to, ShoreKeeper) and has_intro):
                 self.check_combat()
-            # 每次循环迭代先检查复活弹窗（不依赖 in_team 结果）
-            if self.wait_feature('revive_confirm_hcenter_vcenter', threshold=0.6,
-                                 time_out=0.3, raise_if_not_found=False):
-                self.log_info('char dead (detected during switch loop)')
-                if not self.revive_action():
-                    self.raise_not_in_combat('char dead during switch', exception_type=CharDeadException)
             now = time.time()
             current_char.f_break(check_f_on_switch=True)
             _, current_index, _ = self.in_team()
@@ -396,11 +392,9 @@ class BaseCombatTask(CombatCheck):
             in_team, current_index, size = self.in_team()
             if not in_team:
                 logger.info(f'not in team while switching chars_{current_char}_to_{switch_to} {now - start}')
-                confirm = self.wait_feature('revive_confirm_hcenter_vcenter', threshold=0.8, time_out=2)
-                if confirm:
-                    self.log_info(f'char dead')
-                    if not self.revive_action():
-                        self.raise_not_in_combat(f'char dead', exception_type=CharDeadException)
+                # if self.debug:
+                #     self.screenshot(f'not in team while switching chars_{current_char}_to_{switch_to} {now - start}')
+                self.raise_not_in_combat(f'not in_team while switching')
                 if now - start > self.switch_char_time_out:
                     self.raise_not_in_combat(
                         f'switch too long failed chars_{current_char}_to_{switch_to}, {now - start}')
@@ -419,12 +413,6 @@ class BaseCombatTask(CombatCheck):
                     current_time = time.time()
                     self.add_freeze_duration(current_time, switch_to.intro_motion_freeze_duration, -100)
                     current_char.last_outro_time = current_time
-                # 切人成功后补检：目标角色可能已阵亡（弹窗在入场动画期间出现）
-                if self.wait_feature('revive_confirm_hcenter_vcenter', threshold=0.6,
-                                     time_out=0.5, raise_if_not_found=False):
-                    self.log_info('char dead (detected after switch)')
-                    if not self.revive_action():
-                        self.raise_not_in_combat('char dead after switch', exception_type=CharDeadException)
                 break
             self.next_frame()
 

--- a/src/task/BaseCombatTask.py
+++ b/src/task/BaseCombatTask.py
@@ -178,6 +178,8 @@ class BaseCombatTask(CombatCheck):
             self.teleport_to_heal(esc=False)             # ③ 传最近传送点
         finally:
             self.skip_combat_check = prev
+        # 这里刻意返回 False，用于中断当前 combat loop（不是“成功/失败”的语义）。
+        # 上层任务会在捕获异常后重建状态（回到大世界/重进副本/继续循环）。
         return False
 
     def _revive_goto_weekly_entrance(self):

--- a/src/task/BaseCombatTask.py
+++ b/src/task/BaseCombatTask.py
@@ -179,9 +179,6 @@ class BaseCombatTask(CombatCheck):
             self.revive_at_tower_and_heal()
             logger.info(f'revive_action success')
             return True
-        except CharRevivedException:
-            logger.info(f'revive_action success')
-            return True
         except Exception as e:
             logger.error(f'revive_action failed', e)
             return False

--- a/src/task/BaseCombatTask.py
+++ b/src/task/BaseCombatTask.py
@@ -169,7 +169,34 @@ class BaseCombatTask(CombatCheck):
             return 0
 
     def revive_action(self):
-        pass
+        """角色死亡恢复：关闭弹窗 → 传周本入口 → 传最近传送点回血。"""
+        prev = self.skip_combat_check
+        self.skip_combat_check = True
+        try:
+            self.send_key('esc', after_sleep=2)          # ① 关闭复活弹窗
+            self._revive_goto_weekly_entrance()          # ② 传周本锚点
+            self.teleport_to_heal(esc=False)             # ③ 传最近传送点
+        finally:
+            self.skip_combat_check = prev
+        return False
+
+    def _revive_goto_weekly_entrance(self):
+        """复用周本入口作为复活后的稳定锚点。"""
+        self.ensure_main(time_out=80)
+        gray_book_weekly = self.openF2Book('gray_book_weekly')
+        if not gray_book_weekly:
+            self.log_error('revive: gray_book_weekly not found')
+            return
+        self.click_box(gray_book_weekly, after_sleep=1)
+        btn = self.find_one('boss_proceed', box=self.box_of_screen(0.91, 0.3, 0.95, 0.41), threshold=0.8)
+        if not btn:
+            self.log_error('revive: boss_proceed not found')
+            self.ensure_main(time_out=10)
+            return
+        self.click_box(btn, after_sleep=1)
+        self.wait_click_travel()
+        self.wait_in_team_and_world(time_out=120)
+        self.sleep(1)
 
     def teleport_to_heal(self, esc=True):
         """传送回城治疗。"""
@@ -343,6 +370,12 @@ class BaseCombatTask(CombatCheck):
         while True:
             if not (isinstance(switch_to, ShoreKeeper) and has_intro):
                 self.check_combat()
+            # 每次循环迭代先检查复活弹窗（不依赖 in_team 结果）
+            if self.wait_feature('revive_confirm_hcenter_vcenter', threshold=0.6,
+                                 time_out=0.3, raise_if_not_found=False):
+                self.log_info('char dead (detected during switch loop)')
+                if not self.revive_action():
+                    self.raise_not_in_combat('char dead during switch', exception_type=CharDeadException)
             now = time.time()
             current_char.f_break(check_f_on_switch=True)
             _, current_index, _ = self.in_team()
@@ -361,9 +394,7 @@ class BaseCombatTask(CombatCheck):
             in_team, current_index, size = self.in_team()
             if not in_team:
                 logger.info(f'not in team while switching chars_{current_char}_to_{switch_to} {now - start}')
-                # if self.debug:
-                #     self.screenshot(f'not in team while switching chars_{current_char}_to_{switch_to} {now - start}')
-                confirm = self.wait_feature('revive_confirm_hcenter_vcenter', threshold=0.8, time_out=2)
+                confirm = self.wait_feature('revive_confirm_hcenter_vcenter', threshold=0.6, time_out=2)
                 if confirm:
                     self.log_info(f'char dead')
                     if not self.revive_action():
@@ -386,6 +417,12 @@ class BaseCombatTask(CombatCheck):
                     current_time = time.time()
                     self.add_freeze_duration(current_time, switch_to.intro_motion_freeze_duration, -100)
                     current_char.last_outro_time = current_time
+                # 切人成功后补检：目标角色可能已阵亡（弹窗在入场动画期间出现）
+                if self.wait_feature('revive_confirm_hcenter_vcenter', threshold=0.6,
+                                     time_out=0.5, raise_if_not_found=False):
+                    self.log_info('char dead (detected after switch)')
+                    if not self.revive_action():
+                        self.raise_not_in_combat('char dead after switch', exception_type=CharDeadException)
                 break
             self.next_frame()
 

--- a/src/task/BaseCombatTask.py
+++ b/src/task/BaseCombatTask.py
@@ -394,7 +394,7 @@ class BaseCombatTask(CombatCheck):
             in_team, current_index, size = self.in_team()
             if not in_team:
                 logger.info(f'not in team while switching chars_{current_char}_to_{switch_to} {now - start}')
-                confirm = self.wait_feature('revive_confirm_hcenter_vcenter', threshold=0.6, time_out=2)
+                confirm = self.wait_feature('revive_confirm_hcenter_vcenter', threshold=0.8, time_out=2)
                 if confirm:
                     self.log_info(f'char dead')
                     if not self.revive_action():

--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -1079,6 +1079,23 @@ class BaseWWTask(BaseTask):
     def jump(self, after_sleep=0.01):
         self.send_key(self.key_config.get('Jump Key'), after_sleep=after_sleep)
 
+    def go_to_tower(self):
+        self.log_info('go to tower')
+        self.ensure_main(time_out=80)
+        gray_book_weekly = self.openF2Book(Labels.gray_book_weekly)
+        if not gray_book_weekly:
+            self.log_error('go_to_tower can not find gray_book_weekly')
+            return
+        self.click_box(gray_book_weekly, after_sleep=3)
+        btn = self.find_one(Labels.boss_proceed, box=self.box_of_screen(0.91, 0.3, 0.95, 0.41), threshold=0.8)
+        if btn is None:
+            self.ensure_main(time_out=10)
+            return
+        self.click_box(btn, after_sleep=1)
+        self.wait_click_travel()
+        self.wait_in_team_and_world(time_out=120)
+        self.sleep(1)
+
 
 double_drop_color = {
     'r': (140, 180),  # Red range

--- a/src/task/DailyTask.py
+++ b/src/task/DailyTask.py
@@ -97,23 +97,6 @@ class DailyTask(WWOneTimeTask, BaseCombatTask):
         self.claim_battle_pass()
         self.log_info('Task completed', notify=True)
 
-    def go_to_tower(self):
-        self.log_info('go to tower')
-        self.ensure_main(time_out=80)
-        gray_book_weekly = self.openF2Book(Labels.gray_book_weekly)
-        if not gray_book_weekly:
-            self.log_error('go_to_tower can not find gray_book_weekly')
-            return
-        self.click_box(gray_book_weekly, after_sleep=1)
-        btn = self.find_one(Labels.boss_proceed, box=self.box_of_screen(0.91, 0.3, 0.95, 0.41), threshold=0.8)
-        if btn is None:
-            self.ensure_main(time_out=10)
-            return
-        self.click_box(btn, after_sleep=1)
-        self.wait_click_travel()
-        self.wait_in_team_and_world(time_out=120)
-        self.sleep(1)
-
     def claim_battle_pass(self):
         self.log_info('battle pass')
         self.send_key_down('alt')

--- a/src/task/DomainTask.py
+++ b/src/task/DomainTask.py
@@ -3,7 +3,7 @@ import re
 from qfluentwidgets import FluentIcon
 
 from ok import Logger
-from src.task.BaseCombatTask import BaseCombatTask
+from src.task.BaseCombatTask import BaseCombatTask, NotInCombatException, CharDeadException
 from src.task.WWOneTimeTask import WWOneTimeTask
 
 logger = Logger.get_logger(__name__)
@@ -17,6 +17,47 @@ class DomainTask(WWOneTimeTask, BaseCombatTask):
         self.stamina_once = 0
         self.group_name = "Dungeon"
         self.group_icon = FluentIcon.HOME
+
+    def revive_action(self):
+        """副本内死亡恢复：关闭弹窗 → 退出副本 → 传周本入口 → 传最近传送点。"""
+        prev = self.skip_combat_check
+        self.skip_combat_check = True
+        try:
+            # ① 关闭复活弹窗：优先点击弹窗按钮（避免 ESC 注入不生效），失败再回退 ESC
+            closed_by_click = False
+            if self.wait_click_feature('cancel_button_hcenter_vcenter',
+                                       raise_if_not_found=False,
+                                       time_out=1.2,
+                                       click_after_delay=0.2,
+                                       threshold=0.7):
+                closed_by_click = True
+            else:
+                btn_dialog_close = self.find_one('btn_dialog_close', threshold=0.8)
+                if btn_dialog_close:
+                    self.click(btn_dialog_close, move_back=True)
+                    closed_by_click = True
+            if not closed_by_click:
+                self.send_key('esc', after_sleep=2)
+                self.sleep(1)
+
+            # ② 打开退出菜单
+            self.send_key('esc')
+            self.sleep(1)
+
+            # ③ 确认离开
+            self.wait_click_feature('gray_confirm_exit_button',
+                                    relative_x=-1, raise_if_not_found=False,
+                                    time_out=3, click_after_delay=0.5, threshold=0.7)
+
+            # ④ 必须确认已回到大世界队伍态后，再继续走 F2/传送流程
+            if not self.wait_in_team_and_world(time_out=max(self.teleport_timeout, 120), raise_if_not_found=False):
+                return False
+            self.sleep(0.5)
+            self._revive_goto_weekly_entrance()                     # ④ 走周本入口路线
+            self.teleport_to_heal(esc=False)                        # ⑤ 传送最近传送点回血
+        finally:
+            self.skip_combat_check = prev
+        return False
 
     def make_sure_in_world(self):
         if self.in_realm():
@@ -32,6 +73,22 @@ class DomainTask(WWOneTimeTask, BaseCombatTask):
         self.click_box(gray_book_boss, after_sleep=1)
         return self.get_stamina()
 
+    def farm_domain_with_recovery_loop(self, must_use, teleport_into_domain_once):
+        """包装副本刷取循环：死亡恢复后自动从 F2 重新进入。"""
+        while True:
+            current, back_up, total = self.open_F2_book_and_get_stamina()
+            if total < self.stamina_once or total < must_use or (must_use == 0 and current < self.stamina_once):
+                self.log_info('not enough stamina', notify=True)
+                self.back()
+                return
+            teleport_into_domain_once()
+            self.sleep(1)
+            finished = self.farm_in_domain(must_use=must_use)
+            if finished:
+                return
+            self.log_info('farm_domain: death recovered, re-enter from F2 book')
+            self.sleep(1)
+
     def farm_in_domain(self, must_use=0):
         if self.stamina_once <= 0:
             raise RuntimeError('"self.stamina_once" must be override')
@@ -39,10 +96,15 @@ class DomainTask(WWOneTimeTask, BaseCombatTask):
         while True:
             self.walk_until_f(time_out=4, backward_time=0, raise_if_not_found=True)
             self.pick_f()
-            self.combat_once()
-            self.sleep(3)
-            self.walk_to_treasure()
-            self.pick_f(handle_claim=False)
+            try:
+                self.combat_once()
+                self.sleep(3)
+                self.walk_to_treasure()
+                self.pick_f(handle_claim=False)
+            except (NotInCombatException, CharDeadException):
+                self.log_info('farm_in_domain: death recovered, exiting domain')
+                self.make_sure_in_world()
+                return False
             can_continue, used = self.use_stamina(once=self.stamina_once, must_use=must_use)
             self.info_incr('used stamina', used)
             must_use -= used
@@ -68,3 +130,4 @@ class DomainTask(WWOneTimeTask, BaseCombatTask):
         #
         self.click(0.42, 0.84, after_sleep=2)  # back to world
         self.make_sure_in_world()
+        return True

--- a/src/task/DomainTask.py
+++ b/src/task/DomainTask.py
@@ -53,13 +53,10 @@ class DomainTask(WWOneTimeTask, BaseCombatTask):
             if not self.wait_in_team_and_world(time_out=max(self.teleport_timeout, 120), raise_if_not_found=False):
                 return False
             self.sleep(0.5)
-            self._revive_goto_weekly_entrance()                     # ④ 走周本入口路线
-            self.teleport_to_heal(esc=False)                        # ⑤ 传送最近传送点回血
+            self.revive_at_tower_and_heal()
         finally:
             self.skip_combat_check = prev
-        # 这里保持返回 False，用于强制退出当前战斗上下文（不是“成功/失败”的语义）。
-        # 副本死亡恢复会在任务循环层继续推进（更安全的重进路径）。
-        return False
+        return True
 
     def make_sure_in_world(self):
         if self.in_realm():

--- a/src/task/DomainTask.py
+++ b/src/task/DomainTask.py
@@ -20,42 +20,38 @@ class DomainTask(WWOneTimeTask, BaseCombatTask):
 
     def revive_action(self):
         """副本内死亡恢复：关闭弹窗 → 退出副本 → 传周本入口 → 传最近传送点。"""
-        prev = self.skip_combat_check
-        self.skip_combat_check = True
-        try:
-            # ① 关闭复活弹窗：优先点击弹窗按钮（避免 ESC 注入不生效），失败再回退 ESC
-            closed_by_click = False
-            if self.wait_click_feature('cancel_button_hcenter_vcenter',
-                                       raise_if_not_found=False,
-                                       time_out=1.2,
-                                       click_after_delay=0.2,
-                                       threshold=0.7):
-                closed_by_click = True
-            else:
-                btn_dialog_close = self.find_one('btn_dialog_close', threshold=0.8)
-                if btn_dialog_close:
-                    self.click(btn_dialog_close, move_back=True)
-                    closed_by_click = True
-            if not closed_by_click:
-                self.send_key('esc', after_sleep=2)
-                self.sleep(1)
 
-            # ② 打开退出菜单
-            self.send_key('esc')
+        # ① 关闭复活弹窗：优先点击弹窗按钮（避免 ESC 注入不生效），失败再回退 ESC
+        closed_by_click = False
+        if self.wait_click_feature('cancel_button_hcenter_vcenter',
+                                   raise_if_not_found=False,
+                                   time_out=1.2,
+                                   click_after_delay=0.2,
+                                   threshold=0.7):
+            closed_by_click = True
+        else:
+            btn_dialog_close = self.find_one('btn_dialog_close', threshold=0.8)
+            if btn_dialog_close:
+                self.click(btn_dialog_close, move_back=True)
+                closed_by_click = True
+        if not closed_by_click:
+            self.send_key('esc', after_sleep=2)
             self.sleep(1)
 
-            # ③ 确认离开
-            self.wait_click_feature('gray_confirm_exit_button',
-                                    relative_x=-1, raise_if_not_found=False,
-                                    time_out=3, click_after_delay=0.5, threshold=0.7)
+        # ② 打开退出菜单
+        self.send_key('esc')
+        self.sleep(1)
 
-            # ④ 必须确认已回到大世界队伍态后，再继续走 F2/传送流程
-            if not self.wait_in_team_and_world(time_out=max(self.teleport_timeout, 120), raise_if_not_found=False):
-                return False
-            self.sleep(0.5)
-            self.revive_at_tower_and_heal()
-        finally:
-            self.skip_combat_check = prev
+        # ③ 确认离开
+        self.wait_click_feature('gray_confirm_exit_button',
+                                relative_x=-1, raise_if_not_found=False,
+                                time_out=3, click_after_delay=0.5, threshold=0.7)
+
+        # ④ 必须确认已回到大世界队伍态后，再继续走 F2/传送流程
+        if not self.wait_in_team_and_world(time_out=max(self.teleport_timeout, 120), raise_if_not_found=False):
+            return False
+        self.sleep(0.5)
+        self.revive_at_tower_and_heal()
         return True
 
     def make_sure_in_world(self):

--- a/src/task/DomainTask.py
+++ b/src/task/DomainTask.py
@@ -57,6 +57,8 @@ class DomainTask(WWOneTimeTask, BaseCombatTask):
             self.teleport_to_heal(esc=False)                        # ⑤ 传送最近传送点回血
         finally:
             self.skip_combat_check = prev
+        # 这里保持返回 False，用于强制退出当前战斗上下文（不是“成功/失败”的语义）。
+        # 副本死亡恢复会在任务循环层继续推进（更安全的重进路径）。
         return False
 
     def make_sure_in_world(self):
@@ -76,7 +78,7 @@ class DomainTask(WWOneTimeTask, BaseCombatTask):
     def farm_domain_with_recovery_loop(self, must_use, teleport_into_domain_once):
         """包装副本刷取循环：死亡恢复后自动从 F2 重新进入。"""
         while True:
-            current, back_up, total = self.open_F2_book_and_get_stamina()
+            current, _, total = self.open_F2_book_and_get_stamina()
             if total < self.stamina_once or total < must_use or (must_use == 0 and current < self.stamina_once):
                 self.log_info('not enough stamina', notify=True)
                 self.back()

--- a/src/task/DomainTask.py
+++ b/src/task/DomainTask.py
@@ -68,8 +68,9 @@ class DomainTask(WWOneTimeTask, BaseCombatTask):
         self.click_box(gray_book_boss, after_sleep=1)
         return self.get_stamina()
 
-    def farm_domain_with_recovery_loop(self, must_use, teleport_into_domain_once):
-        """包装副本刷取循环：死亡恢复后自动从 F2 重新进入。"""
+    def farm_domain_with_recovery_loop(self, must_use, teleport_into_domain_once, max_recovery_retries=3):
+        """包装副本刷取循环：死亡恢复后自动从 F2 重新进入，并限制重试次数。"""
+        recovery_retries = 0
         while True:
             current, _, total = self.open_F2_book_and_get_stamina()
             if total < self.stamina_once or total < must_use or (must_use == 0 and current < self.stamina_once):
@@ -80,6 +81,12 @@ class DomainTask(WWOneTimeTask, BaseCombatTask):
             self.sleep(1)
             finished = self.farm_in_domain(must_use=must_use)
             if finished:
+                return
+            recovery_retries += 1
+            if recovery_retries >= max_recovery_retries:
+                self.log_info(f'farm_domain: exceeded recovery retries ({max_recovery_retries}), stop farming',
+                              notify=True)
+                self.make_sure_in_world()
                 return
             self.log_info('farm_domain: death recovered, re-enter from F2 book')
             self.sleep(1)

--- a/src/task/NightmareNestTask.py
+++ b/src/task/NightmareNestTask.py
@@ -2,7 +2,7 @@ import re
 import cv2
 from qfluentwidgets import FluentIcon
 from ok import Logger
-from src.task.BaseCombatTask import BaseCombatTask, NotInCombatException
+from src.task.BaseCombatTask import BaseCombatTask, NotInCombatException, CharRevivedException
 from src.task.WWOneTimeTask import WWOneTimeTask
 
 logger = Logger.get_logger(__name__)
@@ -77,7 +77,11 @@ class NightmareNestTask(WWOneTimeTask, BaseCombatTask):
             self.wait_in_team_and_world(time_out=40, raise_if_not_found=False)
         self.sleep(2)
         self.run_until(self.in_combat, 'w', time_out=10, running=False, target=True)
-        self.combat_once(wait_combat_time=0)
+        try:
+            self.combat_once(wait_combat_time=0)
+        except CharRevivedException:
+            self.log_info('nightmare nest: death recovered, re-enter from F2 book')
+            return
         if self._capture_mode:
             if self._capture_success or self.wait_until(self.has_echo_notification, time_out=3):
                 self.log_info("Captured echo during combat, skipping search.")

--- a/src/task/TacetTask.py
+++ b/src/task/TacetTask.py
@@ -1,7 +1,7 @@
 from qfluentwidgets import FluentIcon
 
 from ok import Logger
-from src.task.BaseCombatTask import BaseCombatTask
+from src.task.BaseCombatTask import BaseCombatTask, NotInCombatException, CharDeadException
 from src.task.WWOneTimeTask import WWOneTimeTask
 
 logger = Logger.get_logger(__name__)
@@ -85,10 +85,14 @@ class TacetTask(WWOneTimeTask, BaseCombatTask):
             else:
                 self.walk_until_f(time_out=4, backward_time=0, raise_if_not_found=True)
                 self.pick_f(handle_claim=False)
-            self.combat_once()
-            self.sleep(3)
-            self.walk_to_treasure()
-            self.pick_f(handle_claim=False)
+            try:
+                self.combat_once()
+                self.sleep(3)
+                self.walk_to_treasure()
+                self.pick_f(handle_claim=False)
+            except (NotInCombatException, CharDeadException):
+                self.log_info('farm_tacet: death recovered, re-enter from F2 book')
+                continue
             can_continue, used = self.use_stamina(once=self.stamina_once, must_use=must_use)
             self.info_incr('used stamina', used)
             self.sleep(4)

--- a/src/task/TacetTask.py
+++ b/src/task/TacetTask.py
@@ -1,7 +1,7 @@
 from qfluentwidgets import FluentIcon
 
 from ok import Logger
-from src.task.BaseCombatTask import BaseCombatTask, NotInCombatException, CharDeadException
+from src.task.BaseCombatTask import BaseCombatTask, CharRevivedException
 from src.task.WWOneTimeTask import WWOneTimeTask
 
 logger = Logger.get_logger(__name__)
@@ -90,7 +90,7 @@ class TacetTask(WWOneTimeTask, BaseCombatTask):
                 self.sleep(3)
                 self.walk_to_treasure()
                 self.pick_f(handle_claim=False)
-            except (NotInCombatException, CharDeadException):
+            except CharRevivedException:
                 self.log_info('farm_tacet: death recovered, re-enter from F2 book')
                 continue
             can_continue, used = self.use_stamina(once=self.stamina_once, must_use=must_use)

--- a/tests/TestDomainRecoveryLoop.py
+++ b/tests/TestDomainRecoveryLoop.py
@@ -1,0 +1,64 @@
+import ast
+import unittest
+from pathlib import Path
+
+
+class TestDomainRecoveryLoop(unittest.TestCase):
+    def setUp(self):
+        module = ast.parse(Path("src/task/DomainTask.py").read_text(encoding="utf-8"))
+        class_node = next(
+            node for node in module.body
+            if isinstance(node, ast.ClassDef) and node.name == "DomainTask"
+        )
+        self.method_node = next(
+            node for node in class_node.body
+            if isinstance(node, ast.FunctionDef) and node.name == "farm_domain_with_recovery_loop"
+        )
+
+    def test_method_has_retry_parameter_with_default(self):
+        args = self.method_node.args.args
+        self.assertEqual(args[-1].arg, "max_recovery_retries")
+        self.assertEqual(len(self.method_node.args.defaults), 1)
+        default_value = self.method_node.args.defaults[0]
+        self.assertIsInstance(default_value, ast.Constant)
+        self.assertEqual(default_value.value, 3)
+
+    def test_method_increments_retries(self):
+        has_increment = any(
+            isinstance(node, ast.AugAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "recovery_retries"
+            and isinstance(node.op, ast.Add)
+            and isinstance(node.value, ast.Constant)
+            and node.value.value == 1
+            for node in ast.walk(self.method_node)
+        )
+        self.assertTrue(has_increment)
+
+    def test_method_stops_when_retry_budget_exceeded(self):
+        has_retry_guard = any(
+            isinstance(node, ast.Compare)
+            and isinstance(node.left, ast.Name)
+            and node.left.id == "recovery_retries"
+            and any(isinstance(op, ast.GtE) for op in node.ops)
+            and any(
+                isinstance(comp, ast.Name) and comp.id == "max_recovery_retries"
+                for comp in node.comparators
+            )
+            for node in ast.walk(self.method_node)
+        )
+        self.assertTrue(has_retry_guard)
+
+        has_make_sure_in_world_call = any(
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "self"
+            and node.func.attr == "make_sure_in_world"
+            for node in ast.walk(self.method_node)
+        )
+        self.assertTrue(has_make_sure_in_world_call)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景
当前体力任务在战斗中出现角色死亡时，存在流程中断或状态不一致的问题。  
本次改动基于现有任务框架，补齐死亡恢复链路，确保任务能够自动恢复并继续执行。
---
## 本次新增能力
### 1) 副本体力任务（锻造 / 模拟）死亡恢复闭环
死亡后按以下顺序执行：
1. 关闭复活弹窗  
2. 打开并确认“退出副本”  
3. 等待回到大世界队伍态  
4. 继续后续重进/传送流程  
效果：死亡后不再直接中断，任务可自动续跑。
### 2) 无音区体力任务死亡后继续循环
对死亡相关异常进行显式处理，恢复后进入下一轮循环，避免整任务退出。
### 3) 切人阶段死亡检测增强
在切人关键阶段补充死亡弹窗检测（循环中 + 切人后补检），发现死亡后立即进入恢复流程，减少切人阶段异常中断。
---
## 代码变更范围
### `src/task/BaseCombatTask.py`
- 实现通用 `revive_action()`
- 新增 `_revive_goto_weekly_entrance()`
- 在 `switch_next_char` 中补充死亡弹窗检测与恢复触发
### `src/task/DomainTask.py`
- 覆写 `revive_action()`，副本场景执行“先退本再继续”
- 新增 `farm_domain_with_recovery_loop()`，支持死亡恢复后自动重进
- `farm_in_domain()` 增加死亡异常处理并返回重进信号
### `src/task/TacetTask.py`
- `farm_tacet()` 增加死亡异常处理，恢复后继续循环
---
## 预期结果
- 体力任务在死亡场景下可自动恢复，流程不断链
- 副本与无音区任务在死亡后的行为更加一致
- 提升长时间自动运行的稳定性与可用性


主要是为了给打本打一半卡在那的问题加一个兜底流程（）这次真的把没用的改动都去掉了