### PR TITLE
Add early macOS compatibility scaffolding

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,5 +1,6 @@
 import os
 import re
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -190,3 +191,36 @@ config = {
         ["src.task.FastTravelTask", "FastTravelTask"],
     ], 'scene': ["src.scene.WWScene", "WWScene"],
 }
+
+if sys.platform == 'darwin':
+    # macOS packaging currently cannot re-sign OpenVINO's bundled Intel TBB dylib.
+    # Keep OK-WW's OCR/YOLO flow, but use the official ONNX Runtime code path on Darwin.
+    config['gui_icon'] = os.path.join('icons', 'icon.png')
+    config['ocr']['params']['use_openvino'] = False
+    config['ocr']['params']['use_npu'] = False
+    config['mac'] = {
+        'window_keywords': ['Wuthering Waves', 'Wuthering', '鳴潮', '鸣潮', 'Client-Win64-Shipping'],
+        'owner_keywords': ['Wuthering Waves', 'Wuthering', '鳴潮', '鸣潮', 'Client-Win64-Shipping'],
+        'exclude_owner_keywords': [
+            'Arc', 'Safari', 'Chrome', 'Firefox', 'Code', 'Cursor', 'Terminal', 'iTerm', 'Finder'
+        ],
+        'bundle_ids': ['com.kurogame.wutheringwaves.global'],
+        'include_offscreen': True,
+        'content_ratio': '16:9',
+        'activate_on_capture': False,
+        'activate_on_capture_failure': True,
+        'activation_interval': 1.0,
+        'activate_wait': 1.25,
+        'require_frontmost_for_input': True,
+        'display_fallback_grace': 0.0,
+        'display_fallback_prefer_seconds': 0.75,
+        'display_fallback_settle_wait': 0.75,
+        'display_fallback_window_stable_seconds': 0.45,
+        'display_fallback_when_frontmost': True,
+        'request_screen_capture_on_soft_preflight': False,
+        'startup_capture_timeout': 10.0,
+        'screen_capture_error_delay': 3.0,
+        'min_width': 1280,
+        'min_height': 720,
+        'allow_main_display_fallback': os.environ.get('OKWW_MAC_CAPTURE_DISPLAY') == '1',
+    }

--- a/src/combat/CombatCheck.py
+++ b/src/combat/CombatCheck.py
@@ -1,7 +1,7 @@
 import re
 import time
 
-import win32api
+from src.compat import win32api
 
 from ok import find_boxes_by_name, Logger, calculate_color_percentage
 from ok import find_color_rectangles, get_mask_in_color_range, is_pure_black

--- a/src/compat/__init__.py
+++ b/src/compat/__init__.py
@@ -1,0 +1,1 @@
+"""Compatibility adapters for OS APIs used by upstream OK-WW."""

--- a/src/compat/win32api.py
+++ b/src/compat/win32api.py
@@ -1,0 +1,28 @@
+import importlib
+import sys
+
+
+if sys.platform == "win32":
+    _win32api = importlib.import_module("win32api")
+    GetCursorPos = _win32api.GetCursorPos
+    SetCursorPos = _win32api.SetCursorPos
+else:
+    try:
+        import Quartz
+    except ImportError:
+        Quartz = None
+
+    def _require_quartz():
+        if Quartz is None:
+            raise RuntimeError("Quartz is required for cursor operations on this platform")
+
+    def GetCursorPos():
+        _require_quartz()
+        location = Quartz.CGEventGetLocation(Quartz.CGEventCreate(None))
+        return int(location.x), int(location.y)
+
+    def SetCursorPos(position):
+        _require_quartz()
+        x, y = position
+        Quartz.CGWarpMouseCursorPosition((float(x), float(y)))
+        Quartz.CGAssociateMouseAndMouseCursorPosition(True)

--- a/src/task/AutoCombatTask.py
+++ b/src/task/AutoCombatTask.py
@@ -19,6 +19,7 @@ class AutoCombatTask(BaseCombatTask, TriggerTask):
         self.description = "Enable auto combat in Abyss, Game World etc"
         self.icon = FluentIcon.CALORIES
         self.last_is_click = False
+        self.last_wait_log_time = 0
         self.default_config.update({
             'Auto Target': True,
             'Use Liberation': True,
@@ -34,6 +35,7 @@ class AutoCombatTask(BaseCombatTask, TriggerTask):
     def run(self):
         ret = False
         if not self.scene.in_team(self.in_team_and_world):
+            self.log_waiting('waiting for team HUD')
             return ret
         self.use_liberation = self.config.get('Use Liberation')
         if not self.use_liberation and not self.in_world():  # 仅大世界生效
@@ -51,7 +53,15 @@ class AutoCombatTask(BaseCombatTask, TriggerTask):
                 break
         if ret:
             self.combat_end()
+        else:
+            self.log_waiting('waiting for target or enemy health bar')
         return ret
+
+    def log_waiting(self, reason):
+        now = time.time()
+        if now - self.last_wait_log_time > 5:
+            self.last_wait_log_time = now
+            self.log_info(f'Auto Combat {reason}')
 
     def realm_perform(self):
         if not self.last_is_click:

--- a/src/task/AutoPickTask.py
+++ b/src/task/AutoPickTask.py
@@ -17,6 +17,8 @@ class AutoPickTask(TriggerTask, BaseWWTask):
         self.name = "Auto Pick"
         self.description = "Auto Pick Flowers in Game World"
         self.icon = FluentIcon.SHOPPING_CART
+        self.last_pick_attempt_time = 0
+        self.last_pick_still_visible_log = 0
         self.default_config.update({
             '_enabled': True,
             'Pick Up White List': ['吸收', 'Absorb'],
@@ -26,16 +28,35 @@ class AutoPickTask(TriggerTask, BaseWWTask):
     def send_fs(self):
         # if self.debug:
         #     self.screenshot('pick_up', show_box=True)
-        self.send_key('f')
+        if self.send_key('f') is False:
+            return False
         self.sleep(0.2)
-        self.send_key('f')
+        if self.send_key('f') is False:
+            return False
         self.sleep(0.2)
-        self.send_key('f')
+        if self.send_key('f') is False:
+            return False
         self.sleep(0.2)
+        return True
+
+    def pick_prompt_still_visible(self):
+        self.next_frame()
+        return self.find_one('pick_up_f_hcenter_vcenter', box=self.f_search_box, threshold=0.8)
+
+    def after_pick_attempt(self):
+        if self.pick_prompt_still_visible():
+            now = time.time()
+            if now - self.last_pick_still_visible_log > 2:
+                self.last_pick_still_visible_log = now
+                logger.info('AutoPick input sent but pickup prompt is still visible; not marking success')
+            return False
+        return True
 
     def run(self):
         if not self.scene.in_team(self.in_team_and_world):
             return
+        if time.time() - self.last_pick_attempt_time < 2:
+            return False
         start = time.time()
         while time.time() - start < 1:
             f = self.find_one('pick_up_f_hcenter_vcenter', box=self.f_search_box,
@@ -62,14 +83,18 @@ class AutoPickTask(TriggerTask, BaseWWTask):
                     f = self.find_f_with_text(self.config.get('Pick Up White List'))
                     if f:
                         logger.info(f'found Pick Up White List {f}')
-                        self.send_fs()
-                        return True
+                        self.last_pick_attempt_time = time.time()
+                        if not self.send_fs():
+                            return False
+                        return self.after_pick_attempt()
             else:
                 if self.config.get('Pick Up Black List'):
                     f = self.find_f_with_text(self.config.get('Pick Up Black List'))
                     if f:
                         logger.info(f'found Pick Up Black List: {f}')
                         return False
-                self.send_fs()
-                return True
+                self.last_pick_attempt_time = time.time()
+                if not self.send_fs():
+                    return False
+                return self.after_pick_attempt()
             self.next_frame()

--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -870,11 +870,23 @@ class BaseWWTask(BaseTask):
         return current_direction, current_adjust, False
 
     def in_team(self):
+        horizontal_variance = 0
+        try:
+            device = self.executor.device_manager.get_preferred_device() or {}
+            if device.get('capture') == 'mac' or device.get('device') == 'mac':
+                # macOS native capture is cropped from the real WUWA window bounds
+                # instead of being resized exactly like the Windows templates.
+                horizontal_variance = 0.025
+        except Exception:
+            pass
         c1 = self.find_one('char_1_text',
+                           horizontal_variance=horizontal_variance,
                            threshold=0.8)
         c2 = self.find_one('char_2_text',
+                           horizontal_variance=horizontal_variance,
                            threshold=0.8)
         c3 = self.find_one('char_3_text',
+                           horizontal_variance=horizontal_variance,
                            threshold=0.8)
         arr = [c1, c2, c3]
         # logger.debug(f'in_team check {arr}')

--- a/src/task/MouseResetTask.py
+++ b/src/task/MouseResetTask.py
@@ -1,6 +1,6 @@
 import math
 
-import win32api
+from src.compat import win32api
 from qfluentwidgets import FluentIcon
 
 from ok import TriggerTask, Logger


### PR DESCRIPTION
## Summary
- Add a Darwin configuration block for native macOS WUWA window matching and mac-specific capture/input options.
- Add a small src.compat.win32api shim so existing cursor call sites can keep their shape while delegating to pywin32 on Windows.
- Add low-risk observability/safety improvements found during the macOS port: AutoCombat wait-reason logging, mac-only team HUD tolerance, and AutoPick not treating blocked input or a still-visible pickup prompt as success.

## Current status / caveat
- This is an early macOS compatibility scaffold, not a completed macOS release.
- A local macOS DMG build exists in testing, but end-to-end automation is not successful yet. In particular, AutoCombat still needs more validation/fixes before it can be considered working on macOS.
- The full macOS runtime also depends on macOS capture/input support in the ok-script layer, which is not completed here.
- No DMG, app bundle, logs, screenshots, local paths, signing/TCC details, or build artifacts are included in this PR.

## Security / privacy review before pushing
- Staged diff was checked for local absolute paths, tokens, keys, logs, screenshots, DMGs, artifacts, signing/TCC/codesign details, and generated bytecode.
- PR branch contains source changes only.

## Tests
- python3.12 -m py_compile for the changed Python files
- pytest tests/TestForte.py: 5 passed, 2 warnings
