### PR TITLE
修复自动战斗西格莉卡无法释放强化技能的问题 (#1209)

### DIFF
--- a/src/char/Xigelika.py
+++ b/src/char/Xigelika.py
@@ -45,19 +45,27 @@ class Xigelika(BaseChar):
         use_mouse = self.has_long_action()
         if use_mouse:
             self.task.mouse_down()
-            wait = lambda: not self.has_long_action()
+            try:
+                ret = self.task.wait_until(lambda: not self.has_long_action(), time_out=1.2)
+            finally:
+                self.task.mouse_up()
         else:
             if self.has_cd('resonance'):
                 self.click(interval=0.1)
                 self.sleep(0.05)
                 return False
             self.task.send_key_down(self.get_resonance_key())
-            wait = lambda: not self.is_forte_full()
-        ret = self.task.wait_until(wait, time_out=1.2)
-        if use_mouse:
-            self.task.mouse_up()
-        else:
-            self.task.send_key_up(self.get_resonance_key())
+            start = time.time()
+            ret = False
+            try:
+                while self.time_elapsed_accounting_for_freeze(start) < 1.2:
+                    elapsed = self.time_elapsed_accounting_for_freeze(start)
+                    if elapsed >= 0.6 and not self.is_forte_full():
+                        ret = True
+                        break
+                    self.task.next_frame()
+            finally:
+                self.task.send_key_up(self.get_resonance_key())
         self.sleep(0.01)
         return ret
 


### PR DESCRIPTION
## 问题来源

https://github.com/ok-oldking/ok-wuthering-waves/issues/1209
我自己用起来也这样，看一直没人修干脆就修了

## 根因

原逻辑在满回路后使用：

```python
self.task.send_key_down(self.get_resonance_key())
wait = lambda: not self.is_forte_full()
ret = self.task.wait_until(wait, time_out=1.2)
self.task.send_key_up(self.get_resonance_key())
```

这会导致一个问题：如果按下共鸣技能后的 UI 白色占比短暂掉到阈值以下，`not self.is_forte_full()` 会立刻成立，脚本马上松开按键。

结果就是本应长按的动作变成短按。外层循环继续执行时，又会再次尝试共鸣技能，最终表现为“疯狂点按共鸣技能”。

另外，普通战斗循环中的 `click_resonance(send_click=False, time_out=2)` 本身就是短按型共鸣技能逻辑。如果满回路检测偶发漏判，也会落入这个分支，进一步放大连点表现。

## 修复内容

主要行为变化：

- 共鸣回路满后，长按共鸣技能至少保持 `0.6s`。
- 最多长按 `1.2s`，避免异常情况下卡住按键太久。
- 使用 `try/finally` 包住按键按下/松开，确保中途异常时也会释放按键。

修复后的核心逻辑：

```python
self.task.send_key_down(self.get_resonance_key())
start = time.time()
ret = False
try:
    while self.time_elapsed_accounting_for_freeze(start) < FORTE_HOLD_MAX_SECONDS:
        elapsed = self.time_elapsed_accounting_for_freeze(start)
        if elapsed >= FORTE_HOLD_MIN_SECONDS and not self.is_forte_full():
            ret = True
            break
        self.task.next_frame()
finally:
    self.task.send_key_up(self.get_resonance_key())
```