### PR TITLE
PR  #1263补丁 修复复活流程以后重启刷体力的逻辑，修复传参问题

### DIFF
--- a/src/task/DomainTask.py
+++ b/src/task/DomainTask.py
@@ -79,7 +79,7 @@ class DomainTask(WWOneTimeTask, BaseCombatTask):
                 return
             teleport_into_domain_once()
             self.sleep(1)
-            finished = self.farm_in_domain(must_use=must_use)
+            finished, must_use = self.farm_in_domain(must_use=must_use)
             if finished:
                 return
             recovery_retries += 1
@@ -92,6 +92,10 @@ class DomainTask(WWOneTimeTask, BaseCombatTask):
             self.sleep(1)
 
     def farm_in_domain(self, must_use=0):
+        """刷本循环；返回 (是否整段正常结束, 剩余 must_use)。
+
+        第二项在死亡提前退出时仍会带上本局内已扣过的额度，供外层恢复循环继续传参。
+        """
         if self.stamina_once <= 0:
             raise RuntimeError('"self.stamina_once" must be override')
         self.info_incr('used stamina', 0)
@@ -106,7 +110,7 @@ class DomainTask(WWOneTimeTask, BaseCombatTask):
             except (NotInCombatException, CharDeadException):
                 self.log_info('farm_in_domain: death recovered, exiting domain')
                 self.make_sure_in_world()
-                return False
+                return False, must_use
             can_continue, used = self.use_stamina(once=self.stamina_once, must_use=must_use)
             self.info_incr('used stamina', used)
             must_use -= used
@@ -132,4 +136,4 @@ class DomainTask(WWOneTimeTask, BaseCombatTask):
         #
         self.click(0.42, 0.84, after_sleep=2)  # back to world
         self.make_sure_in_world()
-        return True
+        return True, must_use

--- a/src/task/ForgeryTask.py
+++ b/src/task/ForgeryTask.py
@@ -38,14 +38,12 @@ class ForgeryTask(DomainTask):
             must_use = 0
         if config is None:
             config = self.config
-        current, back_up, total = self.open_F2_book_and_get_stamina()
-        if total < self.stamina_once or total < must_use or (must_use == 0 and current < self.stamina_once):
-            self.log_info(f'not enough stamina', notify=True)
-            self.back()
-            return
-        self.teleport_into_domain(config.get('Which Forgery Challenge to Farm', 1), daily)
-        self.sleep(1)
-        self.farm_in_domain(must_use=must_use)
+        serial = config.get('Which Forgery Challenge to Farm', 1)
+
+        def teleport_once():
+            self.teleport_into_domain(serial, daily)
+
+        self.farm_domain_with_recovery_loop(must_use, teleport_once)
 
     def purification_material(self):
         self.send_key("esc")

--- a/src/task/SimulationTask.py
+++ b/src/task/SimulationTask.py
@@ -38,14 +38,12 @@ class SimulationTask(DomainTask):
             must_use = 0
         if config is None:
             config = self.config
-        current, back_up, total = self.open_F2_book_and_get_stamina()
-        if total < self.stamina_once or total < must_use or (must_use == 0 and current < self.stamina_once):
-            self.log_info(f'not enough stamina', notify=True)
-            self.back()
-            return
-        self.teleport_into_domain(config.get('Material Selection', 'Shell Credit'))
-        self.sleep(1)
-        self.farm_in_domain(must_use=must_use)
+        selection = config.get('Material Selection', 'Shell Credit')
+
+        def teleport_once():
+            self.teleport_into_domain(selection)
+
+        self.farm_domain_with_recovery_loop(must_use, teleport_once)
 
     def teleport_into_domain(self, selection):
         self.click_relative(0.18, 0.28, after_sleep=1)

--- a/tests/TestDomainRecoveryLoop.py
+++ b/tests/TestDomainRecoveryLoop.py
@@ -59,6 +59,20 @@ class TestDomainRecoveryLoop(unittest.TestCase):
         )
         self.assertTrue(has_make_sure_in_world_call)
 
+    def test_loop_unpacks_must_use_from_farm_in_domain(self):
+        has_unpack = any(
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Tuple)
+            and len(node.targets[0].elts) == 2
+            and {elt.id for elt in node.targets[0].elts if isinstance(elt, ast.Name)} == {"finished", "must_use"}
+            and isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Attribute)
+            and node.value.func.attr == "farm_in_domain"
+            for node in ast.walk(self.method_node)
+        )
+        self.assertTrue(has_unpack)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 摘要

- **凝素领域** **模拟领域**：改为走 `farm_domain_with_recovery_loop`，与 #1263 在 `DomainTask` 中提供的「死亡恢复后从 F2 再进本」一致，避免复活成功后任务直接结束、不重进副本。
- **Domain 父类**：`farm_in_domain` 返回 `(finished, remaining_must_use)`，恢复循环中写回外层 `must_use`，修正带日课额度（`must_use > 0`）时「死出去再进」仍沿用初始额度、可能多刷体力的问题（根因在父类循环，非凝素/模拟接线引入）。
- **测试**：`tests/TestDomainRecoveryLoop.py` 增加对 `finished, must_use = self.farm_in_domain(...)` 解包的 AST 回归断言。

## 背景 / 与 #1263 的关系

[#1263](https://github.com/ok-oldking/ok-wuthering-waves/pull/1263) 已描述副本类体力任务应在死亡后退本并续跑，且 `DomainTask` 已提供 `farm_domain_with_recovery_loop`。但 **凝素领域 / 模拟领域** 仍只调用一次 `farm_in_domain`，未接入该循环，与 PR 目标不一致，属集成疏漏。本 PR 补齐接线，并修正父类循环中带额度时的传参。

## 变更文件

| 文件 | 说明 |
|------|------|
| `src/task/ForgeryTask.py` | `farm_forgery` → `farm_domain_with_recovery_loop` |
| `src/task/SimulationTask.py` | `farm_simulation` → `farm_domain_with_recovery_loop` |
| `src/task/DomainTask.py` | `farm_in_domain` 二元组返回值 + 循环内解包更新 `must_use` |
| `tests/TestDomainRecoveryLoop.py` | 解包回归断言 |

## 测试

- [x] **凝素领域**：死亡恢复后能从 F2 再次进本并续刷。
- [x] **模拟领域**：同上。
- [x]  `must_use > 0`：本局已扣部分额度后死亡重进，后续使用剩余额度而非重置为初值。
- [x] `python -m unittest tests.TestDomainRecoveryLoop -v`

## 备注

- 未改 `revive_action` 具体 UI 流程；`max_recovery_retries` 等行为与上游 #1263 保持一致。
- 全库仅 `DomainTask` 调用 `farm_in_domain`，返回值契约变更影响面限于该文件内。