### PR TITLE
移除BaseWWTask中疑似不必要的0.5秒等待

### DIFF
--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -958,7 +958,6 @@ class BaseWWTask(BaseTask):
     def click_traval_button(self):
         for feature_name in ['fast_travel_custom', 'gray_teleport', 'remove_custom']:
             if self.find_one(feature_name, threshold=0.7):
-                self.sleep(0.5)
                 feature = self.find_one(feature_name, threshold=0.7)
                 if not feature:
                     continue


### PR DESCRIPTION
在`src/task/BaseWWTask.py`的第**961行**看到如下代码：
```python
958    def click_traval_button(self):
959        for feature_name in ['fast_travel_custom', 'gray_teleport', 'remove_custom']:
960            if self.find_one(feature_name, threshold=0.7):
961                self.sleep(0.5)
962                feature = self.find_one(feature_name, threshold=0.7)
...
```
我尝试将这行代码注释掉后进行测试，目前没有发现明显异常，相关流程也能正常执行。

如果这段等待已经没有必要，是否可以考虑移除？