### PR TITLE
支持达妮娅轮椅轴与切人逻辑

### DIFF
--- a/src/char/Aemeath.py
+++ b/src/char/Aemeath.py
@@ -96,7 +96,7 @@ class Aemeath(BaseChar):
         if self.has_intro:
             self.record_intro_liberation()
             self.continues_normal_attack(1.2)
-            if self.check_outro() in {'char_linnai', 'char_lupa'}:
+            if self.check_outro() in {'char_linnai', 'char_lupa', 'char_denia'}:
                 self.intro_time = 14
             if self.check_outro() in {'chang_changli', 'char_changli2'}:
                 self.intro_time = 10

--- a/src/char/Denia.py
+++ b/src/char/Denia.py
@@ -3,12 +3,29 @@ from src.char.BaseChar import BaseChar
 
 class Denia(BaseChar):
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.check_f_on_switch = False
+
     def do_perform(self):
         if self.has_intro:
-            self.wait_intro(1.2)
-        if self.resonance_available() and self.click_resonance()[0]:
-            pass
-        if self.click_liberation():
+            self.continues_normal_attack(0.97)
             self.click_resonance()
-        self.click_echo()
+            self.click_echo(time_out=0)
+            if self.click_liberation():
+                self.continues_normal_attack(2.9)
+                self.click_resonance()
+                self.click_liberation()
+        else:
+            if self.resonance_available() and self.click_resonance()[0]:
+                pass
+            if self.click_liberation():
+                self.click_resonance()
+            self.click_echo()
+            
         self.switch_next_char()
+
+    def must_switch(self, current_char=None, has_intro=False, target_low_con=False):
+        if has_intro and current_char and current_char.char_name == 'char_chisa':
+            return True
+        return super().must_switch(current_char, has_intro, target_low_con)

--- a/src/char/Denia.py
+++ b/src/char/Denia.py
@@ -6,23 +6,29 @@ class Denia(BaseChar):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.check_f_on_switch = False
+        self.is_black_form = False
+
+    def reset_state(self):
+        super().reset_state()
+        self.is_black_form = False
 
     def do_perform(self):
         if self.has_intro:
             self.continues_normal_attack(0.97)
-            self.click_resonance()
-            self.click_echo(time_out=0)
+        if not self.is_black_form:
+            if self.resonance_available() and self.click_resonance()[0]:
+                pass
+            self.click_echo()
             if self.click_liberation():
+                self.is_black_form = True  # fall-through to black form below
+        if self.is_black_form:
+            self.click_echo()
+            if not self.liberation_available() and self.has_intro:
                 self.continues_normal_attack(2.9)
-                self.click_resonance()
-                self.click_liberation()
-        else:
             if self.resonance_available() and self.click_resonance()[0]:
                 pass
             if self.click_liberation():
-                self.click_resonance()
-            self.click_echo()
-            
+                self.is_black_form = False
         self.switch_next_char()
 
     def must_switch(self, current_char=None, has_intro=False, target_low_con=False):

--- a/src/char/Denia.py
+++ b/src/char/Denia.py
@@ -1,4 +1,4 @@
-from src.char.BaseChar import BaseChar
+from src.char.BaseChar import BaseChar, SwitchPriority
 
 
 class Denia(BaseChar):
@@ -31,7 +31,7 @@ class Denia(BaseChar):
                 self.is_black_form = False
         self.switch_next_char()
 
-    def must_switch(self, current_char=None, has_intro=False, target_low_con=False):
+    def get_switch_priority(self, current_char=None, has_intro=False, target_low_con=False):
         if has_intro and current_char and current_char.char_name == 'char_chisa':
-            return True
-        return super().must_switch(current_char, has_intro, target_low_con)
+            return SwitchPriority.MUST
+        return super().get_switch_priority(current_char, has_intro, target_low_con)


### PR DESCRIPTION
## 主要改动

- 达妮娅轮椅轴採用
    - 变奏入场 -> a4 -> EQR (若无R则提早切人，顺便对应暗娅变奏入场时的简单轴) -> 4A -> 强化E -> R2 -> 切人
- 切人优化
   - 千咲协奏满时切达妮娅
   - 支持爱弥斯识别达妮娅变奏入场
