### PR TITLE
修复每日任务滚动轴点击位置

### DIFF
--- a/src/task/DailyTask.py
+++ b/src/task/DailyTask.py
@@ -128,7 +128,7 @@ class DailyTask(WWOneTimeTask, BaseCombatTask):
         self.click_box(gray_book_quest, after_sleep=1.5)
         progress = self.ocr(0.1, 0.1, 0.5, 0.75, match=re.compile(r'^(\d+)/180$'))
         if not progress:
-            self.click(0.961, 0.6, after_sleep=1)
+            self.click(0.974, 0.6, after_sleep=1)
             progress = self.ocr(0.1, 0.1, 0.5, 0.75, match=re.compile(r'^(\d+)/180$'))
         if progress:
             current = int(progress[0].name.split('/')[0])


### PR DESCRIPTION
OCR 未抓取到 `^(\d+)/180$` 而尝试向下滚动时点击落空，将 0.961 更改为新版 UI 的 0.974

对应副本等模块中采用的滚动轴横坐标计算公式 scroll_x = 3737 / 3840

```diff
diff --git a/src/task/DailyTask.py b/src/task/DailyTask.py
index 4f1f567..f1c274e 100644
--- a/src/task/DailyTask.py
+++ b/src/task/DailyTask.py
@@ -128,7 +128,7 @@
         self.click_box(gray_book_quest, after_sleep=1.5)
         progress = self.ocr(0.1, 0.1, 0.5, 0.75, match=re.compile(r'^(\d+)/180$'))
         if not progress:
-            self.click(0.961, 0.6, after_sleep=1)
+            self.click(0.974, 0.6, after_sleep=1)
             progress = self.ocr(0.1, 0.1, 0.5, 0.75, match=re.compile(r'^(\d+)/180$'))
         if progress:
             current = int(progress[0].name.split('/')[0])
```