### PR TITLE
fix(farm): wait for boss realm entry prompt

### DIFF
--- a/src/task/FarmEchoTask.py
+++ b/src/task/FarmEchoTask.py
@@ -272,6 +272,12 @@ class FarmEchoTask(WWOneTimeTask, BaseCombatTask):
         raise RuntimeError('Teleport to boss failed')
 
     def walk_until_f_or_combat(self, direction='w', time_out=20):
+        if self.wait_until(lambda: self.in_combat(target=True) or self.in_combat() or self.find_f_with_text(),
+                           time_out=1.5, raise_if_not_found=False):
+            if self.in_combat(target=True) or self.in_combat():
+                return 'combat'
+            return 'f'
+
         self.middle_click(after_sleep=0.2)
         self.send_key_down(direction)
         self.sleep(0.1)
@@ -292,7 +298,7 @@ class FarmEchoTask(WWOneTimeTask, BaseCombatTask):
         raise RuntimeError('Teleport to boss failed: can not walk to combat or F')
 
     def enter_configured_boss_realm_from_f(self):
-        if not self.find_f_with_text():
+        if not self.wait_until(self.find_f_with_text, time_out=2, raise_if_not_found=False):
             raise RuntimeError('Teleport to boss failed: can not find F before entering realm')
         self.send_key('f', after_sleep=3)
         self.click_configured_boss_level()


### PR DESCRIPTION
## Summary

This fixes the weekly boss auto-farm flow for Fleurdelys, the fourth weekly boss.

After teleporting to the boss entrance, the game can already show the `F` / Enter interaction prompt for entering the boss realm. Before this fix, the automation immediately started moving the character forward, which could make the character run past the entrance and lose the interaction prompt. The task then failed with:

```text
Teleport to boss failed: can not find F before entering realm
```

## Solution

- Check for combat state or the `F` interaction prompt before starting movement after a boss teleport.
- If the prompt is already available, enter the realm immediately instead of moving forward.
- Wait briefly for the `F` prompt before pressing it, covering delayed prompt detection after teleport/loading.

## Verification

- Ran Python syntax check for the touched file:

```powershell
.\.venv\Scripts\python.exe -m py_compile .\src\task\FarmEchoTask.py
```

- Tested the Fleurdelys weekly boss auto-farm flow successfully.
- Confirmed the automation no longer runs past the boss realm entrance after teleport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)