### PR TITLE
优化每日任务

### DIFF
--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -1103,10 +1103,11 @@ class BaseWWTask(BaseTask):
     def jump(self, after_sleep=0.01):
         self.send_key(self.key_config.get('Jump Key'), after_sleep=after_sleep)
 
-    def go_to_tower(self):
+    def go_to_tower(self, opened=False):
         self.log_info('go to tower')
-        self.ensure_main(time_out=80)
-        gray_book_weekly = self.openF2Book(Labels.gray_book_weekly)
+        if not opened:
+            self.ensure_main(time_out=80)
+        gray_book_weekly = self.openF2Book(Labels.gray_book_weekly, opened=opened)
         if not gray_book_weekly:
             self.log_error('go_to_tower can not find gray_book_weekly')
             return

--- a/src/task/DailyTask.py
+++ b/src/task/DailyTask.py
@@ -64,16 +64,30 @@ class DailyTask(WWOneTimeTask, BaseCombatTask):
         WWOneTimeTask.run(self)
         self._logged_in = False
         self.ensure_main(time_out=180)
-        self.go_to_tower()
 
         condition1 = self.config.get('Auto Farm all Nightmare Nest')
         condition2 = self.config.get('Farm Nightmare Nest for Daily Echo')
-        if condition1 or condition2:
+
+        used_stamina, daily_reward_ready = self.open_daily()
+        need_stamina = not daily_reward_ready and used_stamina < 180
+        need_nightmare = condition1 or (
+            condition2
+            and not daily_reward_ready
+            and self.config.get('Which to Farm', self.support_tasks[0]) != self.support_tasks[0]
+        )
+
+        if need_nightmare or need_stamina:
+            self.go_to_tower(opened=True)
+
+        if need_nightmare:
             try:
+                # 劫持 NightmareNestTask.ensure_main 避免梦魇打完关书
+                self.get_task_by_class(NightmareNestTask).ensure_main = lambda *args, **kwargs: None
+
                 if condition1:
                     self.log_debug('Auto Farm all Nightmare Nest')
                     self.run_task_by_class(NightmareNestTask)
-                elif condition2 and self.config.get('Which to Farm', self.support_tasks[0]) != self.support_tasks[0]:
+                elif condition2:
                     self.log_debug('Farm Nightmare Nest for Daily Echo')
                     self.get_task_by_class(NightmareNestTask).run_capture_mode()
             except TaskDisabledException:
@@ -82,9 +96,11 @@ class DailyTask(WWOneTimeTask, BaseCombatTask):
                 self.log_error("NightmareNestTask Failed", e)
                 self.screenshot('NightmareNestTask')
                 self.ensure_main(time_out=180)
-        used_stamina, daily_reward_ready = self.open_daily()
-        if not daily_reward_ready and used_stamina < 180:
-            self.send_key('esc', after_sleep=1)
+            finally:
+                # 还原 ensure_main，防范实例状态污染
+                self.get_task_by_class(NightmareNestTask).__dict__.pop('ensure_main', None)
+
+        if need_stamina:
             target = self.config.get('Which to Farm', self.support_tasks[0])
             if target == self.support_tasks[0]:
                 self.get_task_by_class(TacetTask).farm_tacet(daily=True, used_stamina=used_stamina,


### PR DESCRIPTION
开书检测移至 `go_to_tower` 前，确定有 `need_stamina` 或 `need_nightmare` 的需求才进行深塔传送

`need_nightmare` 包含 `condition1（全刷）` 与 `condition2（必要时）且 not daily_reward_ready 且 Which to Farm != 'Tacet Suppression'` 两种情况

同时移除了体力刷取前多余的重复检测与 esc 键发送，并重构 go_to_tower 以支持手册已开启状态

---

```diff
diff --git a/src/task/BaseWWTask.py b/src/task/BaseWWTask.py
index df281b0..dcf12fa 100644
--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -1103,10 +1103,11 @@ class BaseWWTask(BaseTask):
     def jump(self, after_sleep=0.01):
         self.send_key(self.key_config.get('Jump Key'), after_sleep=after_sleep)
 
-    def go_to_tower(self):
+    def go_to_tower(self, opened=False):
         self.log_info('go to tower')
-        self.ensure_main(time_out=80)
-        gray_book_weekly = self.openF2Book(Labels.gray_book_weekly)
+        if not opened:
+            self.ensure_main(time_out=80)
+        gray_book_weekly = self.openF2Book(Labels.gray_book_weekly, opened=opened)
         if not gray_book_weekly:
             self.log_error('go_to_tower can not find gray_book_weekly')
             return
```

註：`go_to_tower(self, opened=False)` 默认参数为 `False`，不会影响 `revive_at_tower_and_heal` 的 `self.go_to_tower()`，並可向下兼容

---

```diff
diff --git a/src/task/DailyTask.py b/src/task/DailyTask.py
index f1c274e..6675434 100644
--- a/src/task/DailyTask.py
+++ b/src/task/DailyTask.py
@@ -64,10 +64,15 @@ class DailyTask(WWOneTimeTask, BaseCombatTask):
         WWOneTimeTask.run(self)
         self._logged_in = False
         self.ensure_main(time_out=180)
-        self.go_to_tower()
 
+        used_stamina, daily_reward_ready = self.open_daily()
         condition1 = self.config.get('Auto Farm all Nightmare Nest')
-        condition2 = self.config.get('Farm Nightmare Nest for Daily Echo')
+        condition2 = self.config.get('Farm Nightmare Nest for Daily Echo')
+        need_stamina = not daily_reward_ready and used_stamina < 180
+        need_nightmare = condition1 or (
+            condition2
+            and not daily_reward_ready
+            and self.config.get('Which to Farm', self.support_tasks[0]) != self.support_tasks[0]
+        )
+
+        if need_nightmare or need_stamina:
+            self.go_to_tower(opened=True)
+
-        if condition1 or condition2:
+        if need_nightmare:
             try:
                 if condition1:
                     self.log_debug('Auto Farm all Nightmare Nest')
                     self.run_task_by_class(NightmareNestTask)
-                elif condition2 and self.config.get('Which to Farm', self.support_tasks[0]) != self.support_tasks[0]:
+                elif condition2:
                     self.log_debug('Farm Nightmare Nest for Daily Echo')
                     self.get_task_by_class(NightmareNestTask).run_capture_mode()
             except TaskDisabledException:
@@ -82,9 +87,8 @@ class DailyTask(WWOneTimeTask, BaseCombatTask):
                 self.log_error("NightmareNestTask Failed", e)
                 self.screenshot('NightmareNestTask')
                 self.ensure_main(time_out=180)
-        used_stamina, daily_reward_ready = self.open_daily()
-        if not daily_reward_ready and used_stamina < 180:
-            self.send_key('esc', after_sleep=1)
+
+        if need_stamina:
             target = self.config.get('Which to Farm', self.support_tasks[0])
             if target == self.support_tasks[0]:
                 self.get_task_by_class(TacetTask).farm_tacet(daily=True, used_stamina=used_stamina,
```