### PR TITLE
1.1 优化角色逻辑

### DIFF
--- a/src/char/Aemeath.py
+++ b/src/char/Aemeath.py
@@ -8,6 +8,8 @@ class Aemeath(BaseChar):
     LIBERATION_FORCE_DURATION = 30
     LIB2_PREPARE_WINDOW = 8
     INTRO_LIBERATION_DELAY = 14
+    ENHANCE_E_REPEAT_GUARD = 2
+    ENHANCE_E_SETTLE_TIME = 0.25
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -135,8 +137,7 @@ class Aemeath(BaseChar):
                 start = time.time()
                 self.should_wait = self.should_wait_for_lib2()
             elif self.enhance_e_available():
-                if self.click_resonance(has_animation=True, send_click=True, animation_min_duration=0.5,
-                                        time_out=1.5)[0]:
+                if self.click_enhance_e_once():
                     self.record_enhance_e()
                     self.click_echo(time_out=0)
                     self.f_break()
@@ -160,8 +161,18 @@ class Aemeath(BaseChar):
         return self.lib1_unlocked() and (0 < cd < 1.5 or self.liberation_available())
 
     def enhance_e_available(self):
+        if self.time_elapsed_accounting_for_freeze(self.last_enhance_e) < self.ENHANCE_E_REPEAT_GUARD:
+            return False
         return self.task.find_one('aemeath_e1', threshold=0.7) or self.task.find_one('aemeath_e2',
                                                                                      threshold=0.7)
+
+    def click_enhance_e_once(self):
+        if not self.enhance_e_available():
+            return False
+        self.record_resonance_use()
+        self.send_resonance_key()
+        self.sleep(self.ENHANCE_E_SETTLE_TIME, check_combat=False)
+        return True
 
     def heavy_wait_highlight_down(self):
         self.task.mouse_down()

--- a/src/char/Linnai.py
+++ b/src/char/Linnai.py
@@ -3,22 +3,35 @@ import time
 from src.char.BaseChar import BaseChar, SwitchPriority, forte_white_color
 
 class Linnai(BaseChar):
+    CON_READY_TO_SWITCH = 0.99
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.last_heavy = 0
 
     def do_perform(self):
         if self.has_intro:
+            if self.is_con_ready_to_switch():
+                return self.switch_next_char()
             if self.check_res():
-                self.continues_normal_attack(1.33)
+                self.continues_normal_attack(1.33, until_con_full=True)
             else:
-                self.continues_normal_attack(1)
+                self.continues_normal_attack(1, until_con_full=True)
+                if self.is_con_ready_to_switch():
+                    return self.switch_next_char()
                 self.click_echo(time_out=0)
-                if not self.is_con_full():
+                if not self.is_con_ready_to_switch():
                     self.click_liberation()
+                if self.is_con_ready_to_switch():
+                    return self.switch_next_char()
                 if not self.is_mouse_forte_full():
-                    self.click_resonance()   
-                self.task.wait_until(self.is_mouse_forte_full, post_action=self.click, time_out=2)
+                    self.click_resonance()
+                if self.is_con_ready_to_switch():
+                    return self.switch_next_char()
+                self.task.wait_until(lambda: self.is_mouse_forte_full() or self.is_con_ready_to_switch(),
+                                     post_action=self.click, time_out=2)
+                if self.is_con_ready_to_switch():
+                    return self.switch_next_char()
                 self.task.mouse_down() 
                 if self.task.wait_until(lambda: not self.is_mouse_forte_full(), time_out=5):
                     self.task.mouse_up()
@@ -29,32 +42,40 @@ class Linnai(BaseChar):
                 
         else: 
             self.click_echo(time_out=0)
-            if self.perform_under_intro():
+            if self.is_con_ready_to_switch():
+                pass
+            elif self.perform_under_intro():
                 pass
             elif self.flying():
                 self.continues_normal_attack(0.1)
-            elif not self.is_con_full() and self.click_liberation():
-                self.continues_normal_attack(0.5)
-            self.click_resonance()
+            elif not self.is_con_ready_to_switch() and self.click_liberation():
+                self.continues_normal_attack(0.5, until_con_full=True)
+            if not self.is_con_ready_to_switch():
+                self.click_resonance()
         return self.switch_next_char()
             
     def perform_under_intro(self):
         if not self.check_res():
             self.logger.debug(f'Linnai fails entering accelerate mode!')
             return False
-        self.task.wait_until(lambda: self.is_color_full() or self.is_con_full(), post_action=self.click,
+        self.task.wait_until(lambda: self.is_color_full() or self.is_con_ready_to_switch(), post_action=self.click,
                                      time_out=1)
-        if self.task.wait_until(lambda: not self.is_forte_full(),
+        if self.is_con_ready_to_switch():
+            return True
+        if self.task.wait_until(lambda: not self.is_forte_full() or self.is_con_ready_to_switch(),
              post_action=self.task.jump, time_out=3):
-        
-            if self.task.wait_until(lambda: self.click_resonance()[0],
+            if self.is_con_ready_to_switch():
+                return True
+            if self.task.wait_until(lambda: self.is_con_ready_to_switch() or self.click_resonance()[0],
              post_action=self.click, time_out=2):
+                if self.is_con_ready_to_switch():
+                    return True
                 self.wait_after_resonance_kick()
                 second_kick = False
 
                 def click_second_resonance():
                     nonlocal second_kick
-                    if self.is_con_full():
+                    if self.is_con_ready_to_switch():
                         return True
                     second_kick = self.click_resonance()[0]
                     return second_kick
@@ -62,9 +83,12 @@ class Linnai(BaseChar):
                 self.task.wait_until(click_second_resonance, post_action=self.click, time_out=3)
                 if second_kick:
                     self.wait_after_resonance_kick()
-        if not self.is_con_full() and self.click_liberation():
-            self.task.wait_until(self.is_con_full, post_action=self.click_with_interval, time_out=1.2) 
+        if not self.is_con_ready_to_switch() and self.click_liberation():
+            self.task.wait_until(self.is_con_ready_to_switch, post_action=self.click_with_interval, time_out=1.2)
         return True
+
+    def is_con_ready_to_switch(self):
+        return self.get_current_con() >= self.CON_READY_TO_SWITCH
 
     def wait_after_resonance_kick(self):
         self.sleep(0.3)

--- a/tests/TestChar.py
+++ b/tests/TestChar.py
@@ -499,6 +499,35 @@ class TestChar(TaskTestCase):
         self.assertEqual(aemeath.actions, ['lib1'])
         self.assertEqual(aemeath.intro_liberation_time, -1)
 
+    def test_aemeath_enhance_e_only_sends_one_resonance_key(self):
+        class Task:
+            def __init__(self):
+                self.keys = []
+                self.skip_combat_check = False
+
+            def time_elapsed_accounting_for_freeze(self, start, intro_motion_freeze=False):
+                return time.time() - start
+
+            def find_one(self, template, threshold=None):
+                return template == 'aemeath_e1'
+
+            def get_resonance_key(self):
+                return 'e'
+
+            def send_key(self, key, interval=-1, down_time=0.01, after_sleep=0):
+                self.keys.append(key)
+
+            def sleep(self, sec):
+                pass
+
+        aemeath = Aemeath(Task(), 0)
+        self.assertTrue(aemeath.click_enhance_e_once())
+        aemeath.record_enhance_e()
+        self.assertEqual(aemeath.task.keys, ['e'])
+
+        self.assertFalse(aemeath.click_enhance_e_once())
+        self.assertEqual(aemeath.task.keys, ['e'])
+
     def test_switch_priority_hooks(self):
         class Task:
             def time_elapsed_accounting_for_freeze(self, start, intro_motion_freeze=False):
@@ -881,6 +910,9 @@ class TestChar(TaskTestCase):
             def is_con_full(self):
                 return False
 
+            def get_current_con(self):
+                return 0
+
             def click_resonance(self, **kwargs):
                 self.resonance_clicks += 1
                 return True, 0, False
@@ -902,6 +934,59 @@ class TestChar(TaskTestCase):
         self.assertEqual(linnai.resonance_clicks, 2)
         self.assertEqual(linnai.actions, [('sleep', 0.3), ('wait_down', True),
                                           ('sleep', 0.3), ('wait_down', True)])
+
+    def test_linnai_switches_without_attack_when_con_ready(self):
+        class Task:
+            pass
+
+        class TestLinnai(Linnai):
+            def __init__(self):
+                super().__init__(Task(), 0)
+                self.has_intro = True
+                self.clicks = 0
+                self.switches = 0
+
+            def get_current_con(self):
+                return 1
+
+            def click(self, *args, **kwargs):
+                self.clicks += 1
+
+            def switch_next_char(self, *args, **kwargs):
+                self.switches += 1
+
+        linnai = TestLinnai()
+        linnai.do_perform()
+        self.assertEqual(linnai.clicks, 0)
+        self.assertEqual(linnai.switches, 1)
+
+    def test_linnai_intro_attack_stops_when_con_full(self):
+        class Task:
+            pass
+
+        class TestLinnai(Linnai):
+            def __init__(self):
+                super().__init__(Task(), 0)
+                self.has_intro = True
+                self.normal_attack_until_con_full = False
+                self.switches = 0
+
+            def get_current_con(self):
+                return 0
+
+            def check_res(self):
+                return True
+
+            def continues_normal_attack(self, duration, **kwargs):
+                self.normal_attack_until_con_full = kwargs.get('until_con_full', False)
+
+            def switch_next_char(self, *args, **kwargs):
+                self.switches += 1
+
+        linnai = TestLinnai()
+        linnai.do_perform()
+        self.assertTrue(linnai.normal_attack_until_con_full)
+        self.assertEqual(linnai.switches, 1)
 
     def test_intro_does_not_switch_to_phrolova_during_liberation_lock(self):
         class Task:


### PR DESCRIPTION
### 爱弥斯
之前的问题是：增强 E 可用时，逻辑走的是通用 click_resonance()。这个方法为了保证技能释放成功，会在技能仍被识别为可用时反复发送 E，并且中间还会穿插普攻点击。爱弥斯的增强 E 本身会切换/改变技能状态，导致脚本可能在短时间内反复按 E，结果一直切状态，实际输出被打断。

现在的修复是：给爱弥斯增强 E 单独走一次性释放逻辑。检测到增强 E 后只发送一次共鸣技能按键，并记录最近释放时间，短时间内不重复触发，避免通用技能点击循环造成反复切换。

### 林奈
之前的问题是：林奈的 perform_under_intro() 和入场分支里，有多处“等待资源/等待技能时持续普攻”的逻辑。协奏看起来已经满了时，如果识别结果还没严格等于 1，或者满协奏发生在等待过程里，脚本仍可能继续普攻、继续等 E，导致切人延迟。

现在的修复是：在林奈内部增加“接近满协奏即可切人”的判断，get_current_con() >= 0.99 就认为可以收手。入场普攻和大招后补协奏的普攻都加了“满协奏即停止”，等待 E、等待资源的阶段也加了满协奏短路，满了就直接返回并切人。