### PR TITLE
fix(workaround): set empty PATH to resolve PySide6 access os.environ['PATH'] issue

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,7 +1,9 @@
 import os
 import re
 from pathlib import Path
-
+# WA: set empty PATH to resolve qfluentwidgets/PySide6 access os.environ['PATH'] issue
+if 'PATH' not in os.environ:
+    os.environ['PATH'] = ""
 from qfluentwidgets import FluentIcon
 
 from ok import Box, ConfigOption


### PR DESCRIPTION
## 问题描述
群友截图：
<img width="1920" height="1440" alt="E26978E522D68EF51C753077D039CD52" src="https://github.com/user-attachments/assets/358fbc9e-66bb-4763-81e7-30636cffd01c" />

## 问题分析
qfluentwidgets中使用了PySide6
PySide6访问了os.environ['PATH']
如果该环境变量不存在则会报错KeyError: 'PATH'
这是PySide6的Bug

## 问题复现
commit: 674f10a389e568b58233bb35f3fe7fb253879c32
```
# git diff
diff --git a/config.py b/config.py
index 98356ef2..8a3fee63 100644
--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 import os
 import re
 from pathlib import Path
+os.environ.pop('PATH')

 from qfluentwidgets import FluentIcon
```

## 问题解决
在import qfluentwidgets前
当系统不存在 PATH 环境变量时
手动将其设置为空字符串
避免 PySide6 /qfluentwidgets 因访问不存在的环境变量而崩溃。

## 最终效果
不加环境变量PATH仍然可以运行