### PR TITLE
修復：在 PySide6 import 前補上 PATH 環境變數，避免 KeyError

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 import os
 if 'PATH' not in os.environ:
-    os.environ['PATH'] = r'C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem'
+    os.environ['PATH'] = os.defpath
 
 if __name__ == '__main__':
     from config import config

--- a/main.py
+++ b/main.py
@@ -1,3 +1,7 @@
+import os
+if 'PATH' not in os.environ:
+    os.environ['PATH'] = r'C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem'
+
 if __name__ == '__main__':
     from config import config
     from ok import OK


### PR DESCRIPTION
透過 Pyappify 啟動時，環境變數中沒有 PATH，
導致 PySide6 初始化時拋出 KeyError 錯誤。

在 main.py 最頂端補上 PATH 的 fallback 修復此問題。