### PR TITLE
update f2 boss book

### DIFF
--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -1091,7 +1091,6 @@ class BaseWWTask(BaseTask):
         self.send_key(self.key_config.get('Jump Key'), after_sleep=after_sleep)
 
     def go_to_tower(self, opened=False):
-        breakpoint()
         self.log_info('go to tower')
         if not opened:
             self.ensure_main(time_out=80)

--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -938,7 +938,7 @@ class BaseWWTask(BaseTask):
         self.log_info(f'open_boss_book {name}')
         x = 0.24
         self.sleep(0.4)
-        if name == 'lingyu':
+        if name == 'ningsu':
             y = 0.28
         elif name == 'moni':
             y = 0.39
@@ -950,9 +950,13 @@ class BaseWWTask(BaseTask):
             y = 0.7
         elif name == 'mengyan':
             y = 0.81
+        elif name == 'canxiang':
+            # 点击滚轮翻页
+            for _ in range(3):
+                self.click_relative(685/1920,955/1080, after_sleep=after_sleep)
+            y = 0.81
         else:
             raise Exception(f'unknown_lang {name}')
-
         self.click_relative(x, y, after_sleep=after_sleep, name=name)
 
     def openF2Book(self, feature="gray_book_all_monsters", opened=False):

--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -938,20 +938,18 @@ class BaseWWTask(BaseTask):
         self.log_info(f'open_boss_book {name}')
         x = 0.24
         self.sleep(0.4)
-        if name == 'wuyin':
-            y = 0.49
-        elif name == 'canxiang':
-            y = 0.81
-        elif name == 'zhange':
-            y = 0.6
-        elif name == 'mengyan':
-            y = 0.7
-        elif name == 'moni':
+        if name == 'lingyu':
             y = 0.28
-        elif name == 'canxiang':
-            y = 0.81
-        elif name == 'qiangdi':
+        elif name == 'moni':
             y = 0.39
+        elif name == 'qiangdi':
+            y = 0.49
+        elif name == 'wuyin':
+            y = 0.6
+        elif name == 'zhange':
+            y = 0.7
+        elif name == 'mengyan':
+            y = 0.81
         else:
             raise Exception(f'unknown_lang {name}')
 
@@ -1093,6 +1091,7 @@ class BaseWWTask(BaseTask):
         self.send_key(self.key_config.get('Jump Key'), after_sleep=after_sleep)
 
     def go_to_tower(self, opened=False):
+        breakpoint()
         self.log_info('go to tower')
         if not opened:
             self.ensure_main(time_out=80)


### PR DESCRIPTION
<img width="1920" height="1080" alt="Windows Graphics Capture_1920x1080_1780914965199 4207_original" src="https://github.com/user-attachments/assets/5cbf1d12-6560-4831-88db-6bd1ca38e497" />
更新F2 boss列表

更新后可成功进入：【讨伐强敌】，【无音区】，【战歌重奏】，【梦魇祓除】，【残像聚落】

对于【残像聚落】，根据群友 undefined 的建议，点击滚轮进行翻页

因为【凝素领域】和【模拟领域】未使用该处代码逻辑，所以下一步需要单独支持它们