### PR TITLE
适配3.4，更新索拉指南坐标

### DIFF
--- a/src/task/DailyTask.py
+++ b/src/task/DailyTask.py
@@ -166,6 +166,7 @@ class DailyTask(WWOneTimeTask, BaseCombatTask):
         self.info_set('current task', 'claim daily')
         if not self.find_one('boss_proceed', box=self.box_of_screen(0.803, 0.189, 0.960, 0.312)):
             self.log_info('no_boss_proceed, click claim')
+            # Click [Guidebook] in [Terminal] interface
             self.click(1270 / 2560, 1050 / 1440, after_sleep=2)
         self.click_daily_reward_box(100)
         self.ensure_main(time_out=10)

--- a/src/task/DailyTask.py
+++ b/src/task/DailyTask.py
@@ -166,7 +166,7 @@ class DailyTask(WWOneTimeTask, BaseCombatTask):
         self.info_set('current task', 'claim daily')
         if not self.find_one('boss_proceed', box=self.box_of_screen(0.803, 0.189, 0.960, 0.312)):
             self.log_info('no_boss_proceed, click claim')
-            self.click(0.881, 0.237, after_sleep=2)
+            self.click(1270 / 2560, 1050 / 1440, after_sleep=2)
         self.click_daily_reward_box(100)
         self.ensure_main(time_out=10)
 


### PR DESCRIPTION
<img width="2560" height="1440" alt="Windows Graphics Capture_2560x1440_1780981713891 502_original" src="https://github.com/user-attachments/assets/71961232-3082-4c67-9088-f3cdd68ac66b" />
ui更新

导致【领取每日】时点击原坐标(0.881, 0.237)会进入【唤取】界面

更新坐标后可以正确的进入【索拉指南】