### PR TITLE
处理 find_feature 返回空数组的情况

### DIFF
--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -1060,7 +1060,7 @@ class BaseWWTask(BaseTask):
             height = item_h * serial_number
             self.click(bar_x, bar_top + height, after_sleep=1)
         btns = self.find_feature('boss_proceed', box=self.box_of_screen(0.9113, 0.229, 0.9613, 0.861), threshold=0.8)
-        if btns is None or len(btns) <= 0:
+        if not btns:
             raise Exception("can't find boss_proceed")
         if target_index > -1:
             target = btns[target_index]

--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -1060,7 +1060,7 @@ class BaseWWTask(BaseTask):
             height = item_h * serial_number
             self.click(bar_x, bar_top + height, after_sleep=1)
         btns = self.find_feature('boss_proceed', box=self.box_of_screen(0.9113, 0.229, 0.9613, 0.861), threshold=0.8)
-        if btns is None:
+        if btns is None or len(btns) <= 0:
             raise Exception("can't find boss_proceed")
         if target_index > -1:
             target = btns[target_index]

--- a/src/task/SimulationTask.py
+++ b/src/task/SimulationTask.py
@@ -50,7 +50,7 @@ class SimulationTask(DomainTask):
         self.info_set('Teleport to Simulation Challenge', selection)
         self.click_relative(0.980, 0.875, after_sleep=1)
         btns = self.find_feature('boss_proceed', box=self.box_of_screen(0.94, 0.26, 0.97, 0.88), threshold=0.8)
-        if btns is None:
+        if btns is None or len(btns) <= 0:
             raise Exception("can't find boss_proceed")
         top_btn = min(btns, key=lambda box: box.y)
         self.click_box(top_btn, after_sleep=1)

--- a/src/task/SimulationTask.py
+++ b/src/task/SimulationTask.py
@@ -50,7 +50,7 @@ class SimulationTask(DomainTask):
         self.info_set('Teleport to Simulation Challenge', selection)
         self.click_relative(0.980, 0.875, after_sleep=1)
         btns = self.find_feature('boss_proceed', box=self.box_of_screen(0.94, 0.26, 0.97, 0.88), threshold=0.8)
-        if btns is None or len(btns) <= 0:
+        if not btns:
             raise Exception("can't find boss_proceed")
         top_btn = min(btns, key=lambda box: box.y)
         self.click_box(top_btn, after_sleep=1)


### PR DESCRIPTION
`find_feature` 找不到的情况下可能返回空数组，对空数组使用 min 和 max 函数会直接报错 `ValueError: max() iterable argument is empty`。

处于代码修改最小化的考虑，我只改动了相关的两处。**建议 review 所有调用 find_feature 的地方，对空数组情形进行处理。**