### PR TITLE
优化爱弥斯、绯雪技能释放

### DIFF
--- a/src/char/Aemeath.py
+++ b/src/char/Aemeath.py
@@ -17,6 +17,8 @@ class Aemeath(BaseChar):
         self.last_enhance_e = -1
         self.intro_liberation_time = -1
         self.pending_lib2 = False
+        self._lib1_cast_count = 0   # 本轮 lib1 释放次数
+        self._lib2_cast_count = 0   # 本轮 lib2 释放次数
 
     def lib2_cooldown_anchor(self):
         if self.last_liber >= 0:
@@ -87,12 +89,129 @@ class Aemeath(BaseChar):
             self.pending_lib2 = False
             self.last_liber = time.time()
             self.last_enhance_e = self.last_liber
+            self._lib2_cast_count += 1
         else:
             self.intro_liberation_time = -1
+            self._lib1_cast_count += 1
+
+    def _lib1_cast_this_turn(self):
+        """本轮上场后是否已释放过 lib1（第一次解放）。"""
+        return self._lib1_cast_count > 0
+
+    def _lib2_cast_this_turn(self):
+        """本轮上场后是否已释放过 lib2（第二次解放）。"""
+        return self._lib2_cast_count > 0
+
+    def _execute_lib2_guard(self, context_log: str = "") -> None:
+        """
+        进入等待循环以确保第二次解放（lib2）被释放。
+        包含 13 秒的超时保护机制，防止长时间死循环。
+        """
+        lib2_guard_start = time.time()
+        self.logger.info(f'Aemeath [do_perform] waiting for lib2 before switching {context_log}')
+        
+        while not self._lib2_cast_this_turn():
+            # 超时保护（13秒），防止 lib2 长时间不就绪导致死循环
+            if time.time() - lib2_guard_start > 13:
+                self.logger.warning(f'Aemeath [do_perform] lib2 guard timed out (13s) {context_log}, casting switch')
+                break
+                
+            self.check_combat()
+            if self.handle_heavy():
+                self.logger.debug(f'Aemeath [do_perform] handle_heavy triggered during lib2 guard {context_log}')
+                self.task.next_frame()
+                continue
+                
+            if self.lib2_available():
+                if self.lib():
+                    self.logger.debug(f'Aemeath [do_perform] lib2 cast, integrity guard satisfied {context_log}')
+                    break
+                    
+            if self.enhance_e_available():
+                self.click_resonance(has_animation=True, send_click=True,
+                                     animation_min_duration=0.5, time_out=1.5)
+            self.click(after_sleep=0.01)
+            self.task.next_frame()
+
+    def _execute_lib1_or_fallback_guard(self) -> None:
+        """
+        处理本轮尚未释放任何解放（lib1）的情况。
+        在 8 秒窗口内尝试释放 lib1 或共鸣技能。如果成功释放 lib1，则级联调用 lib2 守护。
+        """
+        lib_guard_start = time.time()
+        found_action = False
+
+        while time.time() - lib_guard_start < 10.0:
+            self.check_combat()
+            
+            if self.liberation_available() and self.can_cast_lib1():
+                self.logger.debug('Aemeath [do_perform] lib available but not cast — casting lib1')
+                self.lib()
+                found_action = True 
+                # 成功释放 lib1 后，直接复用 lib2 的等待逻辑
+                self._execute_lib2_guard(context_log="(after forced lib1)")
+                break
+                
+            elif self.enhance_e_available():
+                self.logger.info('Aemeath [do_perform] resonance available but not cast — casting resonance')
+                self.click_resonance(has_animation=True, send_click=True,
+                                     animation_min_duration=0.5, time_out=1.5)
+                found_action = True
+                break
+                
+            else:
+                if not self.handle_heavy():
+                    self.click(after_sleep=0.01)
+                self.task.next_frame()
+
+        if not found_action:
+            self.logger.warning(
+                'Aemeath [do_perform] 8s window elapsed with no available skill, '
+                'allowing switch without liberation'
+            )
+
+    def _execute_post_lib2_combo(self):
+        """
+        lib2 释放后的强制收尾连招：3次普攻 + 共鸣技能(E)
+        """
+        self.logger.info('Aemeath [post-lib2 combo] starting: 3 Normal Attacks -> Resonance (E)')
+        
+        # 1. 执行 3 次普攻
+        for i in range(3):
+            self.check_combat()  # 每次攻击前检查战斗状态，防止超时或脱战导致的死循环
+            self.normal_attack()
+            self.sleep(0.25)      # 普攻间隔，可根据 Aemeath 实际动作帧长微调
+            
+        self.check_combat()
+        
+        # 2. 检查并释放 E 技能 (优先检查增强E，若无则检查基础E是否可用)
+        e_available = self.enhance_e_available() or not self.task.has_cd('resonance')
+        
+        if e_available:
+            self.logger.info('Aemeath [post-lib2 combo] E available, casting resonance')
+            self.click_resonance(has_animation=True, send_click=True, animation_min_duration=0.5, time_out=1.5)
+            self.record_enhance_e()  # 同步更新状态机，记录E释放时间
+        else:
+            self.logger.info('Aemeath [post-lib2 combo] E not available, skipping')
+
+
+    def _process_end_of_turn_liberations(self) -> None:
+        """根据当前回合的解放技能释放状态，进行决策路由并执行相应的收尾动作。"""
+        if self._lib1_cast_this_turn() and not self._lib2_cast_this_turn():
+            # ── 分支A：本轮已释放 lib1 但未释放 lib2，必须等待并释放 lib2 ───────
+            self._execute_lib2_guard(context_log="(initial lib1 cast)")
+            
+        elif not self._lib1_cast_this_turn() and not self._lib2_cast_this_turn():
+            # ── 分支B：本轮既未释放 lib1 也未释放 lib2，尝试 8 秒 fallback ──────
+            self._execute_lib1_or_fallback_guard()
 
     def do_perform(self):
         self.intro_time = -1
         self.should_wait = False
+        # 重置本轮计数
+        self._lib1_cast_count = 0
+        self._lib2_cast_count = 0
+        
         if self.has_intro:
             self.record_intro_liberation()
             self.continues_normal_attack(1.2)
@@ -100,7 +219,12 @@ class Aemeath(BaseChar):
                 self.intro_time = 14
             if self.check_outro() in {'chang_changli', 'char_changli2'}:
                 self.intro_time = 10
+                
         self.perform_everything()
+
+        # 处理回合末尾的技能链（lib1 -> lib2）的完整性约束
+        self._process_end_of_turn_liberations()
+
         self.switch_next_char()
 
     def lib(self):
@@ -111,6 +235,9 @@ class Aemeath(BaseChar):
             return False
         self.record_liberation(is_lib2)
         self.f_break()
+
+        if is_lib2:
+            self._execute_post_lib2_combo()
         return True
 
     def continue_in_intro(self):

--- a/src/char/Hiyuki.py
+++ b/src/char/Hiyuki.py
@@ -1,96 +1,143 @@
 import time
-
 from src.char.BaseChar import BaseChar, SwitchPriority
 
 class Hiyuki(BaseChar):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.lib_permission = True
+        # 记录 Lib2 居合判定的次数
+        self.lib2_count = 0
+        self.time_out = 12.5
+
+    def switch_out(self, con_full=False):
+        """角色切出时重置状态"""
+        super().switch_out(con_full)
+        self.lib2_count = 0
+        self.lib_permission = True  # 切出时重置
 
     def do_perform(self):
         if self.has_intro:
             self.continues_normal_attack(1)
-        if self.has_long_action2() and self.lib_permission and self.liberation_available():
-            self.hold_liberation()
+
+        if self.has_long_action2():
+            lib_success = self.perform_lib()
+            if lib_success:
+                self.sleep(0.5)
+                self.switch_next_char()
+                return  
+
+            elif self.lib_permission and self.liberation_available():
+                if self.hold_liberation():
+                    self.lib_permission = False
+                    self.sleep(0.5)
+                    self.switch_next_char()
+                    return
+
         if self.has_long_action() and not self.has_cd('liberation'):
             self.perform_standard()
-        if self.has_long_action2():
-            self.perform_lib()
+
         self.switch_next_char()
-            
-            
-    def perform_standard(self):        
-        timeout = 6
+
+    def perform_standard(self):
+        timeout = self.time_out
         if self.has_intro and self.check_outro() in {'char_linnai'}:
-            timeout = 18
+            timeout = 18.0
+
         while self.has_long_action() and self.time_elapsed_accounting_for_freeze(self.last_perform) < timeout:
             self.click_echo(time_out=0)
-            if self.click_liberation():
-                self.logger.debug('hiyuki perform lib1')
-                self.lib_permission = False
-                return
-            if self.is_mouse_forte_full():
-                self.task.click(key="right")
-                self.heavy_click_forte(check_fun=self.is_mouse_forte_full)
-                self.task.wait_until(self.liberation_available, post_action=self.click_with_interval, time_out=6)
+            self.click_resonance(send_click=False, time_out=0)
+
+            if self.liberation_available():
                 if self.click_liberation():
                     self.logger.debug('hiyuki perform lib1')
                     self.lib_permission = False
                     return
-            self.click_resonance(send_click=False, time_out=0)
-            self.click(interval=0.1)
+
+            if self.is_mouse_forte_full():
+                self.task.click(key="right")
+                self.heavy_click_forte(check_fun=self.is_mouse_forte_full)
+                self.task.wait_until(self.liberation_available, post_action=self.click_with_interval, time_out=self.time_out)
+                if self.click_liberation():
+                    self.logger.debug('hiyuki perform lib1')
+                    self.lib_permission = False
+                    return
+            else:
+                self.click(interval=0.1)
             self.sleep(0.05)
-            
-    def perform_lib(self):  
+
+    def perform_lib(self):
         start = time.time()
-        timeout = 6
+        timeout = self.time_out
         if self.has_intro and self.check_outro() in {'char_linnai'}:
-            timeout = 18
+            timeout = 18.0
+
+        is_timeout = False
+
         while self.has_long_action2() and self.time_elapsed_accounting_for_freeze(self.last_perform) < timeout:
             self.f_break()
             self.click_echo(time_out=0)
-            self.logger.debug(f'hiyuki find mouse_forte{self.task.find_one('hiyuki_lib_forte', threshold=0.7)}')
-            if self.lib_permission and self.liberation_available():
-                self.hold_liberation()
-                self.logger.debug('hiyuki perform lib2')
-                return
+            self.logger.debug(f"hiyuki find mouse_forte{self.task.find_one('hiyuki_lib_forte', threshold=0.7)}")
+
+            # 终结技释放判定 (最高优先级，确保满足条件时立刻执行)
+            is_timeout = self.time_elapsed_accounting_for_freeze(self.last_perform) >= timeout - 0.5
+            if self.lib_permission and self.liberation_available() and (self.lib2_count >= 4 or is_timeout):
+                if self.hold_liberation():
+                    self.logger.info(f'hiyuki perform lib2 after heavy (count: {self.lib2_count}, timeout: {is_timeout})')
+                    self.lib2_count = 0
+                    return True
+
+            # 提高共鸣技能释放优先级
             if self.click_resonance(send_click=False, time_out=0)[0]:
-                if timeout == 6 and self.time_elapsed_accounting_for_freeze(start) > 2:
-                    return
+                if is_timeout:
+                    break
                 self.continues_normal_attack(0.3)
             elif self.lib_heavy_available():
                 self.heavy_click_forte(check_fun=self.lib_heavy_available)
                 self.lib_permission = True
                 if self.task.wait_until(self.liberation_available, post_action=self.click, time_out=0.5):
-                    self.hold_liberation()
-                    self.logger.debug('hiyuki perform lib2')
-                return
+                    if self.hold_liberation():
+                        self.logger.debug('hiyuki perform lib2 (after heavy)')
+                        self.lib2_count = 0
+                        return True
+                self.lib2_count += 1
+                self.sleep(0.1)
+                self.logger.debug(f"hiyuki heavy  count: {self.lib2_count}")
             elif bool(self.task.find_one('hiyuki_left', threshold=0.5)):
                 self.task.wait_until(lambda: not bool(self.task.find_one('hiyuki_left', threshold=0.5)),
-                 post_action=self.click, time_out=3)
-                if timeout == 6 and self.time_elapsed_accounting_for_freeze(start) > 2:
-                    return 
+                                     post_action=self.click, time_out=3.0)
+                if is_timeout:
+                    break
                 self.sleep(0.1)
             elif bool(self.task.find_one('hiyuki_right', threshold=0.5)):
                 self.task.click(key="right", interval=1.0)
                 self.sleep(0.1)
             else:
-                self.click()           
+                self.click()
+
             self.sleep(0.05)
-            
+        
+        # 循环外的兜底判定 (防止循环退出时大招刚好就绪)
+        if self.lib_permission and self.liberation_available():
+            if self.hold_liberation():
+                self.logger.warning('hiyuki perform lib2 (final fallback)')
+                self.lib2_count = 0
+                return True
+
+        return False
+
     def lib_heavy_available(self):
         return bool(self.task.find_one('hiyuki_lib_forte', threshold=0.7))
-        
+
     def hold_liberation(self):
         if not self.task.use_liberation:
             return False
         last_click = 0
         self.logger.debug('hold_liberation start')
         start = time.time()
-        while self.task.in_team()[0] and self.liberation_available() and time.time() - start < 8:  
+        while self.task.in_team()[0] and self.liberation_available() and time.time() - start < 8.0:
             if time.time() - start > last_click:
                 self.task.send_key_down(self.get_liberation_key())
-                last_click += 0.5
+                last_click += 0.2
             if self.task.in_team()[0]:
                 self.sleep(0.05)
         self.task.in_liberation = True


### PR DESCRIPTION
优化了 Aemeath 与 Hiyuki 两个角色的战斗策略。

关于 Aemeath 角色的修改：一是实现优先一轮双大不切人，引入了单回合大招计数器，在初始化中新增了释放次数统计，并在每次上场时重置，精准追踪大招释放状态。二是新增了末尾收尾检查，在准备切人前进行强制状态校验。如果本轮释放了第一段大招却漏了第二段大招，会触发守护逻辑强行等待并释放第二段大招，内置了13秒超时保护防止卡死；如果本轮什么技能都没放，则提供10秒窗口尝试强行放大招或释放E技能兜底。三是，注入了最优连招，成功释放第二段大招后会自动触发收尾连招，执行3次普攻接共鸣技能E的高收益轮椅轴。

关于 Hiyuki 角色的修改：一是引入了状态重置与计数，用来追踪第二段大招的居合判定次数，并在角色切出时主动重置状态，防止跨回合状态污染。二是将大招释放条件标准化，在循环中将大招释放机制调整为最高优先级，当满足判定次数大于等于4次或接近超时的时候立刻触发大招，避免提前释放大招。三是优化了长按机制与循环外兜底，将长按大招的按键间隔从0.5秒加密至0.2秒以提升动作响应速度，同时在循环外部增加了一层最终兜底判定，确保在退出循环的瞬间若大招刚好就绪，依然能成功打出，绝对不浪费能量。

这些修改带来的改进收益主要体现在三个方面：第一是实现了零大招漏放，严格的逻辑守护确保了核心第二段大招的完整释放率。第二是具备极高的运行稳定性，无论是 Aemeath 的13秒或10秒超时保护，还是 Hiyuki 的循环外兜底，都通过了防卡死测试。第三是带来了整体输出的提升，规范了招式收尾，例如 Aemeath 大招后的3次普攻加E技能，最大化了输出轴的利用率。