### PR TITLE
修复 open_daily 函数的 bug

### DIFF
--- a/src/task/DailyTask.py
+++ b/src/task/DailyTask.py
@@ -138,6 +138,7 @@ class DailyTask(WWOneTimeTask, BaseCombatTask):
         self.log_info('open_daily')
         gray_book_quest = self.openF2Book("gray_book_quest")
         self.click_box(gray_book_quest, after_sleep=1.5)
+        self.click(0.17, 0.12, after_sleep=1)
         progress = self.ocr(0.1, 0.1, 0.5, 0.75, match=re.compile(r'^(\d+)/180$'))
         if not progress:
             self.click(0.974, 0.6, after_sleep=1)
@@ -148,6 +149,7 @@ class DailyTask(WWOneTimeTask, BaseCombatTask):
             current = 0
         self.info_set('current daily progress', current)
         return current, self.get_total_daily_points() >= 100
+        # 请注意：如果任务【累计消耗180点结晶波片】已完成，current 也可能为 0，因为翻页后也有可能识别不到已用体力。
 
     def get_total_daily_points(self):
         points_boxes = self.ocr(0.19, 0.8, 0.30, 0.93, match=number_re)


### PR DESCRIPTION
如果活跃度任务已完成，F2 打开后会自动进入 周度游历，这种情况下，需要增加一次点击回到 活跃度。

<img width="1920" height="1080" alt="Windows Graphics Capture_1920x1080_1781224833270 9197_original" src="https://github.com/user-attachments/assets/f83e63f4-98a6-4acb-aa7c-e57920ac33b1" />

此外，如果活跃度任务已完成，current 仍然可能由于识别不到已用体力而为 0，因此加了注释。

<img width="1920" height="1080" alt="Windows Graphics Capture_1920x1080_1781224850424 3398_original" src="https://github.com/user-attachments/assets/4ea8e7ef-7428-446f-af91-b23d837179cb" />

