### PR TITLE
修复角色死亡复活流程：搜索"无冠者"定位稳定传送点回血

### DIFF
--- a/src/task/BaseCombatTask.py
+++ b/src/task/BaseCombatTask.py
@@ -182,10 +182,34 @@ class BaseCombatTask(CombatCheck):
         else:
             return 0
 
+    def close_revive_popup(self):
+        """关闭角色死亡弹窗。
+
+        优先点击弹窗按钮 (避免 ESC 注入偶发不生效)，依次尝试:
+        cancel_button → btn_dialog_close → 最后回退 ESC。
+        供 BaseCombatTask 与 DomainTask 的死亡恢复共用, 保证关弹窗稳定。
+
+        Returns:
+            bool: True 表示通过点击按钮关闭, False 表示回退到了 ESC。
+        """
+        if self.wait_click_feature('cancel_button_hcenter_vcenter',
+                                   raise_if_not_found=False,
+                                   time_out=1.2,
+                                   click_after_delay=0.2,
+                                   threshold=0.7):
+            return True
+        btn_dialog_close = self.find_one('btn_dialog_close', threshold=0.8)
+        if btn_dialog_close:
+            self.click(btn_dialog_close, move_back=True)
+            return True
+        self.send_key('esc', after_sleep=2)
+        self.sleep(1)
+        return False
+
     def revive_action(self):
-        """角色死亡恢复：关闭弹窗 → 传周本入口 → 传最近传送点回血。"""
+        """角色死亡恢复：关闭弹窗 → 传最近传送点回血。"""
         try:
-            self.send_key('esc', after_sleep=2)  # ① 关闭复活弹窗
+            self.close_revive_popup()  # ① 关闭复活弹窗 (点按钮优先, esc 兜底)
             self.revive_at_tower_and_heal()
             logger.info(f'revive_action success')
             return True
@@ -194,16 +218,40 @@ class BaseCombatTask(CombatCheck):
             return False
 
     def revive_at_tower_and_heal(self):
-        """Use the weekly entrance as a stable anchor, then teleport to heal."""
-        self.teleport_to_heal()
+        """搜索无冠者→探测打开地图→找最近传送点回血。
+
+        不再依赖已被移除的 go_to_tower。改用 F2 图鉴搜索"无冠者"后点"探测"，
+        游戏会把地图定位到固定位置，从该位置寻找传送点回血，结果稳定可复现。
+        前提：调用前已回到大世界 (副本内死亡需先退本)。
+        """
+        # 退本后可能仍在加载黑屏, 给足超时等待真正回到大世界 (原 go_to_tower 用 80s)
+        self.ensure_main(time_out=120)
+        # ① F2 图鉴 → 全部怪物 → 搜索"无冠者"
+        gray_book = self.openF2Book("gray_book_all_monsters")
+        self.click_box(gray_book, after_sleep=1)
+        self.click(0.13, 0.14, after_sleep=0.5)        # 搜索图标
+        self.input_text("无冠者")
+        self.sleep(0.3)
+        self.click(0.20, 0.14, after_sleep=0.3)         # 点搜索框确保焦点
+        self.send_key('enter', after_sleep=0.5)          # 回车确认搜索, 刷新结果列表
+        self.click(0.13, 0.24, after_sleep=0.5)         # 选中第一条结果
+        # ② 点"探测"——打开地图并定位到无冠者位置 (点两次, 与 teleport_to_nearest_boss 一致)
+        self.click(0.89, 0.92, after_sleep=1)
+        self.click(0.89, 0.92, after_sleep=1)
+        # ③ 在已打开的地图上找最近传送点回血
+        self._travel_to_nearest_waypoint()
 
     def teleport_to_heal(self):
-        """传送回城治疗。"""
+        """按 M 开图, 就近找传送点回血 (供 FarmEchoTask 在 boss 点使用)。"""
         self.ensure_main(time_out=10)
         self.log_info('click m to open the map')
         start = time.time()
         while self.in_team_and_world() and time.time() - start < 20:
             self.send_key('m', after_sleep=2)
+        self._travel_to_nearest_waypoint()
+
+    def _travel_to_nearest_waypoint(self):
+        """在已打开的地图界面上, 找最近传送点并传送, 等回到大世界。"""
         self.sleep(2)
         teleport = self.find_best_match_in_box(self.box_of_screen(0.1, 0.1, 0.9, 0.9),
                                                ['map_way_point', 'map_way_point_big'], 0.6)

--- a/src/task/DomainTask.py
+++ b/src/task/DomainTask.py
@@ -19,24 +19,10 @@ class DomainTask(WWOneTimeTask, BaseCombatTask):
         self.group_icon = FluentIcon.HOME
 
     def revive_action(self):
-        """副本内死亡恢复：关闭弹窗 → 退出副本 → 传周本入口 → 传最近传送点。"""
+        """副本内死亡恢复：关闭弹窗 → 退出副本 → 传最近传送点回血。"""
 
-        # ① 关闭复活弹窗：优先点击弹窗按钮（避免 ESC 注入不生效），失败再回退 ESC
-        closed_by_click = False
-        if self.wait_click_feature('cancel_button_hcenter_vcenter',
-                                   raise_if_not_found=False,
-                                   time_out=1.2,
-                                   click_after_delay=0.2,
-                                   threshold=0.7):
-            closed_by_click = True
-        else:
-            btn_dialog_close = self.find_one('btn_dialog_close', threshold=0.8)
-            if btn_dialog_close:
-                self.click(btn_dialog_close, move_back=True)
-                closed_by_click = True
-        if not closed_by_click:
-            self.send_key('esc', after_sleep=2)
-            self.sleep(1)
+        # ① 关闭复活弹窗 (点按钮优先, esc 兜底, 与 BaseCombatTask 共用)
+        self.close_revive_popup()
 
         # ② 打开退出菜单
         self.send_key('esc')


### PR DESCRIPTION
## 背景

`go_to_tower` 被移除后，角色死亡复活流程 `revive_at_tower_and_heal` 改为就地按 M 找最近传送点。但部分传送点对 OCR 不友好，复活经常因找不到传送点而失败，导致日常任务中断。

## 改动

1. **改用稳定锚点定位**：`revive_at_tower_and_heal` 改为在 F2 图鉴搜索固定世界 BOSS「无冠者」→点「探测」，游戏会把地图定位到固定位置，再从该地图找最近传送点回血。位置固定 → 结果稳定可复现，不再依赖死亡地点附近恰好有易识别的传送点。

2. **统一关弹窗助手 `close_revive_popup`**：依次 `cancel_button` → `btn_dialog_close` → `esc` 兜底。`BaseCombatTask` 与 `DomainTask` 共用，修复无音区等开放世界死亡时 ESC 注入偶发不生效、弹窗关不掉的问题。

3. **抽出 `_travel_to_nearest_waypoint`**：搜怪补血与 `FarmEchoTask.teleport_to_heal`（boss 点就地补血）共用「找传送点 + 传送」逻辑，避免重复。

4. **退本加载容错**：`revive_at_tower_and_heal` 的 `ensure_main` 超时 `10s → 120s`，恢复原 `go_to_tower` 的退本加载等待，修复副本退出加载黑屏期间误报 `Please start in game world and in team!`。

## 测试

无音区 / 凝素领域 / 模拟领域 / 梦魇巢穴 单独运行均已验证：死亡 → 关弹窗 →（副本先退本）→ 搜索无冠者补血 → 重新开始任务，全流程正常。

## 兼容性

- `AutoCombatTask` 仍按原设计排除自动复活（大世界半自动战斗交由玩家处理）。
- `close_revive_popup` 找不到按钮时回退 `esc`（即原行为），严格只增不减。