### PR TITLE
feat(daily): 新增配置项「完成日常后继续刷取体力直到耗尽」

### DIFF
--- a/i18n/zh_CN/LC_MESSAGES/ok.po
+++ b/i18n/zh_CN/LC_MESSAGES/ok.po
@@ -741,6 +741,12 @@ msgstr "使用梦魇巢穴获取日常声骸"
 msgid "Farm 1 Echo from Nightmare Nest to complete Daily Task when needed."
 msgstr "必要时，前往梦魇巢穴获取声骸完成日常"
 
+msgid "Continue Farm After Daily"
+msgstr "完成日常后继续刷取体力"
+
+msgid "After completing daily activity, continue farming stamina until depleted."
+msgstr "在完成日常任务活跃度之后仍然刷取体力直到体力耗尽"
+
 msgid "F10"
 msgstr ""
 

--- a/i18n/zh_TW/LC_MESSAGES/ok.po
+++ b/i18n/zh_TW/LC_MESSAGES/ok.po
@@ -741,6 +741,12 @@ msgstr "使用夢魘巢穴獲取日常聲骸"
 msgid "Farm 1 Echo from Nightmare Nest to complete Daily Task when needed."
 msgstr "必要時，前往夢魘巢穴取得聲骸完成日常"
 
+msgid "Continue Farm After Daily"
+msgstr "完成日常後繼續刷取體力"
+
+msgid "After completing daily activity, continue farming stamina until depleted."
+msgstr "在完成日常任務活躍度之後仍然刷取體力直到體力耗盡"
+
 msgid "F10"
 msgstr ""
 

--- a/src/task/BaseCombatTask.py
+++ b/src/task/BaseCombatTask.py
@@ -182,10 +182,34 @@ class BaseCombatTask(CombatCheck):
         else:
             return 0
 
+    def close_revive_popup(self):
+        """关闭角色死亡弹窗。
+
+        优先点击弹窗按钮 (避免 ESC 注入偶发不生效)，依次尝试:
+        cancel_button → btn_dialog_close → 最后回退 ESC。
+        供 BaseCombatTask 与 DomainTask 的死亡恢复共用, 保证关弹窗稳定。
+
+        Returns:
+            bool: True 表示通过点击按钮关闭, False 表示回退到了 ESC。
+        """
+        if self.wait_click_feature('cancel_button_hcenter_vcenter',
+                                   raise_if_not_found=False,
+                                   time_out=1.2,
+                                   click_after_delay=0.2,
+                                   threshold=0.7):
+            return True
+        btn_dialog_close = self.find_one('btn_dialog_close', threshold=0.8)
+        if btn_dialog_close:
+            self.click(btn_dialog_close, move_back=True)
+            return True
+        self.send_key('esc', after_sleep=2)
+        self.sleep(1)
+        return False
+
     def revive_action(self):
-        """角色死亡恢复：关闭弹窗 → 传周本入口 → 传最近传送点回血。"""
+        """角色死亡恢复：关闭弹窗 → 传最近传送点回血。"""
         try:
-            self.send_key('esc', after_sleep=2)  # ① 关闭复活弹窗
+            self.close_revive_popup()  # ① 关闭复活弹窗 (点按钮优先, esc 兜底)
             self.revive_at_tower_and_heal()
             logger.info(f'revive_action success')
             return True
@@ -194,16 +218,40 @@ class BaseCombatTask(CombatCheck):
             return False
 
     def revive_at_tower_and_heal(self):
-        """Use the weekly entrance as a stable anchor, then teleport to heal."""
-        self.teleport_to_heal()
+        """搜索无冠者→探测打开地图→找最近传送点回血。
+
+        不再依赖已被移除的 go_to_tower。改用 F2 图鉴搜索"无冠者"后点"探测"，
+        游戏会把地图定位到固定位置，从该位置寻找传送点回血，结果稳定可复现。
+        前提：调用前已回到大世界 (副本内死亡需先退本)。
+        """
+        # 退本后可能仍在加载黑屏, 给足超时等待真正回到大世界 (原 go_to_tower 用 80s)
+        self.ensure_main(time_out=120)
+        # ① F2 图鉴 → 全部怪物 → 搜索"无冠者"
+        gray_book = self.openF2Book("gray_book_all_monsters")
+        self.click_box(gray_book, after_sleep=1)
+        self.click(0.13, 0.14, after_sleep=0.5)        # 搜索图标
+        self.input_text("无冠者")
+        self.sleep(0.3)
+        self.click(0.20, 0.14, after_sleep=0.3)         # 点搜索框确保焦点
+        self.send_key('enter', after_sleep=0.5)          # 回车确认搜索, 刷新结果列表
+        self.click(0.13, 0.24, after_sleep=0.5)         # 选中第一条结果
+        # ② 点"探测"——打开地图并定位到无冠者位置 (点两次, 与 teleport_to_nearest_boss 一致)
+        self.click(0.89, 0.92, after_sleep=1)
+        self.click(0.89, 0.92, after_sleep=1)
+        # ③ 在已打开的地图上找最近传送点回血
+        self._travel_to_nearest_waypoint()
 
     def teleport_to_heal(self):
-        """传送回城治疗。"""
+        """按 M 开图, 就近找传送点回血 (供 FarmEchoTask 在 boss 点使用)。"""
         self.ensure_main(time_out=10)
         self.log_info('click m to open the map')
         start = time.time()
         while self.in_team_and_world() and time.time() - start < 20:
             self.send_key('m', after_sleep=2)
+        self._travel_to_nearest_waypoint()
+
+    def _travel_to_nearest_waypoint(self):
+        """在已打开的地图界面上, 找最近传送点并传送, 等回到大世界。"""
         self.sleep(2)
         teleport = self.find_best_match_in_box(self.box_of_screen(0.1, 0.1, 0.9, 0.9),
                                                ['map_way_point', 'map_way_point_big'], 0.6)

--- a/src/task/DailyTask.py
+++ b/src/task/DailyTask.py
@@ -32,12 +32,14 @@ class DailyTask(WWOneTimeTask, BaseCombatTask):
             'Material Selection': 'Shell Credit',
             'Auto Farm all Nightmare Nest': False,
             'Farm Nightmare Nest for Daily Echo': True,
+            'Continue Farm After Daily': False,
         }
         self.config_description = {
             'Which Tacet Suppression to Farm': 'The Tacet Suppression number in the F2 list.',
             'Which Forgery Challenge to Farm': 'The Forgery Challenge number in the F2 list.',
             'Material Selection': 'Resonator EXP / Weapon EXP / Shell Credit',
-            'Farm Nightmare Nest for Daily Echo': 'Farm 1 Echo from Nightmare Nest to complete Daily Task when needed.'
+            'Farm Nightmare Nest for Daily Echo': 'Farm 1 Echo from Nightmare Nest to complete Daily Task when needed.',
+            'Continue Farm After Daily': 'After completing daily activity, continue farming stamina until depleted.'
         }
         material_option_list = ['Resonator EXP', 'Weapon EXP', 'Shell Credit']
         self.config_type = {
@@ -96,16 +98,20 @@ class DailyTask(WWOneTimeTask, BaseCombatTask):
                 # 还原 ensure_main，防范实例状态污染
                 self.get_task_by_class(NightmareNestTask).__dict__.pop('ensure_main', None)
 
-        if need_stamina:
+        continue_farm = self.config.get('Continue Farm After Daily', False)
+
+        if need_stamina or continue_farm:
             target = self.config.get('Which to Farm', self.support_tasks[0])
+            # continue_farm=True → daily=False（刷到体力耗尽）；否则 daily=True（仅刷到日常所需）
+            use_daily = not continue_farm
             if target == self.support_tasks[0]:
-                self.get_task_by_class(TacetTask).farm_tacet(daily=True, used_stamina=used_stamina,
+                self.get_task_by_class(TacetTask).farm_tacet(daily=use_daily, used_stamina=used_stamina,
                                                              config=self.config)
             elif target == self.support_tasks[1]:
-                self.get_task_by_class(ForgeryTask).farm_forgery(daily=True, used_stamina=used_stamina,
+                self.get_task_by_class(ForgeryTask).farm_forgery(daily=use_daily, used_stamina=used_stamina,
                                                                  config=self.config)
             else:
-                self.get_task_by_class(SimulationTask).farm_simulation(daily=True, used_stamina=used_stamina,
+                self.get_task_by_class(SimulationTask).farm_simulation(daily=use_daily, used_stamina=used_stamina,
                                                                        config=self.config)
             self.sleep(4)
 

--- a/src/task/DomainTask.py
+++ b/src/task/DomainTask.py
@@ -19,24 +19,10 @@ class DomainTask(WWOneTimeTask, BaseCombatTask):
         self.group_icon = FluentIcon.HOME
 
     def revive_action(self):
-        """副本内死亡恢复：关闭弹窗 → 退出副本 → 传周本入口 → 传最近传送点。"""
+        """副本内死亡恢复：关闭弹窗 → 退出副本 → 传最近传送点回血。"""
 
-        # ① 关闭复活弹窗：优先点击弹窗按钮（避免 ESC 注入不生效），失败再回退 ESC
-        closed_by_click = False
-        if self.wait_click_feature('cancel_button_hcenter_vcenter',
-                                   raise_if_not_found=False,
-                                   time_out=1.2,
-                                   click_after_delay=0.2,
-                                   threshold=0.7):
-            closed_by_click = True
-        else:
-            btn_dialog_close = self.find_one('btn_dialog_close', threshold=0.8)
-            if btn_dialog_close:
-                self.click(btn_dialog_close, move_back=True)
-                closed_by_click = True
-        if not closed_by_click:
-            self.send_key('esc', after_sleep=2)
-            self.sleep(1)
+        # ① 关闭复活弹窗 (点按钮优先, esc 兜底, 与 BaseCombatTask 共用)
+        self.close_revive_popup()
 
         # ② 打开退出菜单
         self.send_key('esc')


### PR DESCRIPTION
## 变更内容

新增配置项 `Continue Farm After Daily`（完成日常后继续刷取体力），开启后日常任务在刷满 180 活跃度后不会停手，继续刷取同一副本直到体力（含备用体力）完全耗尽。

### 改动文件

| 文件 | 改动 |
|---|---|
| `src/task/DailyTask.py` | 新增配置项 + 修改 `run()` 中 daily 参数逻辑 |
| `i18n/zh_CN/LC_MESSAGES/ok.po` | 添加中英文翻译 |
| `i18n/zh_TW/LC_MESSAGES/ok.po` | 添加繁中翻译 |

### 逻辑说明

- **选项关闭**（默认）：`daily=True` → 副本内 `must_use = 180 - used_stamina`，刷够活跃度即停，行为不变
- **选项开启**：`daily=False` → `must_use = 0`，体力池低于单次消耗才停

### 使用场景

当前体力 60/180，备用体力 120，今日已用 50：
- **关闭**：消耗 130 体力，到达 180 活跃度即停
- **开启**：消耗 180 体力直到总体力不足单次刷新