### PR TITLE
feat(daily): 新增配置项「完成日常后继续刷取体力直到耗尽」

### DIFF
--- a/i18n/zh_CN/LC_MESSAGES/ok.po
+++ b/i18n/zh_CN/LC_MESSAGES/ok.po
@@ -741,6 +741,12 @@ msgstr "使用梦魇巢穴获取日常声骸"
 msgid "Farm 1 Echo from Nightmare Nest to complete Daily Task when needed."
 msgstr "必要时，前往梦魇巢穴获取声骸完成日常"
 
+msgid "Continue Farm After Daily"
+msgstr "完成日常后继续刷取体力"
+
+msgid "After completing daily activity, continue farming stamina until depleted."
+msgstr "在完成日常任务活跃度之后仍然刷取体力直到体力耗尽"
+
 msgid "F10"
 msgstr ""
 

--- a/i18n/zh_TW/LC_MESSAGES/ok.po
+++ b/i18n/zh_TW/LC_MESSAGES/ok.po
@@ -741,6 +741,12 @@ msgstr "使用夢魘巢穴獲取日常聲骸"
 msgid "Farm 1 Echo from Nightmare Nest to complete Daily Task when needed."
 msgstr "必要時，前往夢魘巢穴取得聲骸完成日常"
 
+msgid "Continue Farm After Daily"
+msgstr "完成日常後繼續刷取體力"
+
+msgid "After completing daily activity, continue farming stamina until depleted."
+msgstr "在完成日常任務活躍度之後仍然刷取體力直到體力耗盡"
+
 msgid "F10"
 msgstr ""
 

--- a/src/task/DailyTask.py
+++ b/src/task/DailyTask.py
@@ -34,6 +34,7 @@ class DailyTask(WWOneTimeTask, BaseCombatTask):
             'Auto Farm all Nightmare Nest': False,
             'Farm Nightmare Nest for Daily Echo': True,
             'Check Weekly Garden': True,
+            'Continue Farm After Daily': False,
         }
         self.config_description = {
             'Which Tacet Suppression to Farm': 'The Tacet Suppression number in the F2 list.',
@@ -41,7 +42,8 @@ class DailyTask(WWOneTimeTask, BaseCombatTask):
             'Material Selection': 'Resonator EXP / Weapon EXP / Shell Credit',
             'Farm Nightmare Nest for Daily Echo': 'Farm 1 Echo from Nightmare Nest to complete Daily Task when needed.',
             'Check Weekly Garden': 'After claiming daily rewards, check weekly Garden progress and run Garden Task '
-                                   'if 6000 points has not been reached.'
+                                   'if 6000 points has not been reached.',
+            'Continue Farm After Daily': 'After completing daily activity, continue farming stamina until depleted.'
         }
         material_option_list = ['Resonator EXP', 'Weapon EXP', 'Shell Credit']
         self.config_type = {
@@ -100,16 +102,20 @@ class DailyTask(WWOneTimeTask, BaseCombatTask):
                 # 还原 ensure_main，防范实例状态污染
                 self.get_task_by_class(NightmareNestTask).__dict__.pop('ensure_main', None)
 
-        if need_stamina:
+        continue_farm = self.config.get('Continue Farm After Daily', False)
+
+        if need_stamina or continue_farm:
             target = self.config.get('Which to Farm', self.support_tasks[0])
+            # continue_farm=True → daily=False（刷到体力耗尽）；否则 daily=True（仅刷到日常所需）
+            use_daily = not continue_farm
             if target == self.support_tasks[0]:
-                self.get_task_by_class(TacetTask).farm_tacet(daily=True, used_stamina=used_stamina,
+                self.get_task_by_class(TacetTask).farm_tacet(daily=use_daily, used_stamina=used_stamina,
                                                              config=self.config)
             elif target == self.support_tasks[1]:
-                self.get_task_by_class(ForgeryTask).farm_forgery(daily=True, used_stamina=used_stamina,
+                self.get_task_by_class(ForgeryTask).farm_forgery(daily=use_daily, used_stamina=used_stamina,
                                                                  config=self.config)
             else:
-                self.get_task_by_class(SimulationTask).farm_simulation(daily=True, used_stamina=used_stamina,
+                self.get_task_by_class(SimulationTask).farm_simulation(daily=use_daily, used_stamina=used_stamina,
                                                                        config=self.config)
             self.sleep(4)
 


### PR DESCRIPTION
## 变更内容

新增配置项 `Continue Farm After Daily`（完成日常后继续刷取体力），
开启后日常任务在刷满 180 活跃度后不会停手，继续刷取同一副本直到体力（含备用体力）完全耗尽。

### 逻辑

| 选项 | daily 参数 | 行为 |
|---|---|---|
| 关闭（默认） | `daily=True` | `must_use = 180 - used_stamina`，刷够活跃度即停 |
| 开启 | `daily=False` | `must_use = 0`，体力池低于单次消耗才停 |

### 改动文件

`src/task/DailyTask.py` — 新增配置项 + run() 中 daily 参数逻辑
`i18n/zh_CN + zh_TW` — 添加翻译