### PR TITLE
fix: 死亡复活流程仅点一次探测，等待地图打开后再操作

### DIFF
--- a/src/task/BaseCombatTask.py
+++ b/src/task/BaseCombatTask.py
@@ -222,6 +222,7 @@ class BaseCombatTask(CombatCheck):
 
         不再依赖已被移除的 go_to_tower。改用 F2 图鉴搜索"无冠者"后点"探测"，
         游戏会把地图定位到固定位置，从该位置寻找传送点回血，结果稳定可复现。
+        只点一次"探测"，等待地图打开后再操作，防止二次点击误触地图上的传送图标。
         前提：调用前已回到大世界 (副本内死亡需先退本)。
         """
         # 退本后可能仍在加载黑屏, 给足超时等待真正回到大世界 (原 go_to_tower 用 80s)
@@ -235,10 +236,16 @@ class BaseCombatTask(CombatCheck):
         self.click(0.20, 0.14, after_sleep=0.3)         # 点搜索框确保焦点
         self.send_key('enter', after_sleep=0.5)          # 回车确认搜索, 刷新结果列表
         self.click(0.13, 0.24, after_sleep=0.5)         # 选中第一条结果
-        # ② 点"探测"——打开地图并定位到无冠者位置 (点两次, 与 teleport_to_nearest_boss 一致)
+        # ② 点"探测"打开地图并定位到无冠者 (只点一次, 避免地图打开后误触传送点)
         self.click(0.89, 0.92, after_sleep=1)
-        self.click(0.89, 0.92, after_sleep=1)
-        # ③ 在已打开的地图上找最近传送点回血
+        # ③ 等待地图打开 (检测地图传送点), 若未打开则补点一次兜底
+        if not self.wait_until(lambda: self.find_best_match_in_box(
+                self.box_of_screen(0.1, 0.1, 0.9, 0.9),
+                ['map_way_point', 'map_way_point_big'], 0.6) is not None,
+                time_out=4, raise_if_not_found=False):
+            logger.warning('revive_at_tower_and_heal: map not opened, retry探测')
+            self.click(0.89, 0.92, after_sleep=1)
+        # ④ 在已打开的地图上找最近传送点回血
         self._travel_to_nearest_waypoint()
 
     def teleport_to_heal(self):


### PR DESCRIPTION
对 #1378 的补充修复。

### 问题
#1378 引入的双点击模式（点两次 0.89, 0.92）在实际运行中存在误触：
第二次点击时地图已打开，坐标恰好落在无冠者传送点上，导致角色被
传送到 BOSS 位置而非最近的回血传送点，后续刷本流程出错。

### 修复
- **revive_at_tower_and_heal**: 只点一次"探测"，用 wait_until 检测
  地图传送点图标确认地图打开后再走传送流程。若 4s 超时未检测到
  (UI 卡顿)，才补点一次兜底。
- **BaseCombatTask / DomainTask**: 统一使用 close_revive_popup()
  关闭复活弹窗，消除重复代码。
- **teleport_to_nearest_boss** (FarmEchoTask): 同样移除冗余的第二次
  点击，改用 teleport_to_nearest_waypoint_on_map 替代。

### 变更文件
- src/task/BaseCombatTask.py
- src/task/DomainTask.py
- src/task/FarmEchoTask.py