### PR TITLE
fix: return [] instead of None when OpenVINO YOLO detection fails

### DIFF
--- a/src/OpenVinoYolo8Detect.py
+++ b/src/OpenVinoYolo8Detect.py
@@ -141,4 +141,4 @@ class OpenVinoYolo8Detect:
             return sort_boxes(boxes)
         except Exception as e:
             logger.error(f'OpenVINO yolo detect error: {e}')
-            return
+            return []


### PR DESCRIPTION
## Problem

`OpenVinoYolo8Detect.detect()` catches inference errors, logs them, then does a bare `return` — which returns `None`:

```python
        except Exception as e:
            logger.error(f'OpenVINO yolo detect error: {e}')
            return        # -> None
```

But callers treat the result as a list:

- `globals.py` `yolo_detect()` is a thin passthrough: `return self.yolo_model.detect(...)` (no `None` normalization).
- `BaseWWTask.find_echos` does `for box in ret:` (`BaseWWTask.py:552`).
- `BaseWWTask.yolo_find_all` does `sorted(boxes, ...)` (`BaseWWTask.py:571`).

So when OpenVINO inference throws (e.g. a transient driver/model error during echo farming), the already-logged, recoverable error is turned into an unhandled crash:

```
TypeError: 'NoneType' object is not iterable
```

This is on the **default** backend (OpenVINO is selected via `use_openvino`).

## Fix

Return `[]` instead, so a failed detection degrades gracefully to "no detections found". This matches:

1. the sibling `OnnxYolo8Detect.detect()`, which already returns `[]` in the same `except` branch, and
2. the function's normal contract (the success path returns the list from `sort_boxes`).

```diff
         except Exception as e:
             logger.error(f'OpenVINO yolo detect error: {e}')
-            return
+            return []
```

## Verification

Reproduced offline (no game / GPU needed) by forcing the `except` branch and exercising the caller pattern:

- After the fix, `detect()` returns `[]` on error; `for box in ret` and `sorted(ret, ...)` run cleanly.
- Before the fix, the same caller pattern raises `TypeError: 'NoneType' object is not iterable`.

One-line change, error path only.
