### PR TITLE
1.5 修复边缘奖励

### DIFF
--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -335,7 +335,7 @@ class BaseWWTask(BaseTask):
         return "w" if delta_y > 0 else "s"
 
     def find_treasure_icon(self):
-        return self.find_one('treasure_icon', box=self.box_of_screen(0.18, 0.1, 0.82, 0.81), threshold=0.8,
+        return self.find_one('treasure_icon', box=self.box_of_screen(0.03, 0.1, 0.97, 0.81), threshold=0.8,
                              target_height=720)
 
     def click(self, x=-1, y=-1, move_back=False, name=None, interval=-1, move=False, down_time=0.01, after_sleep=0,


### PR DESCRIPTION
## 修改内容
- 扩大奖励图标的水平搜索范围，从 18%~82% 调整为 3%~97%
- 解决奖励图标出现在屏幕边缘时可能识别不到的问题

## 验证
- python -m py_compile src/task/BaseWWTask.py
- python -m unittest tests.TestTacet