### PR TITLE
1.6 修复死亡切人

### DIFF
--- a/src/task/AutoCombatTask.py
+++ b/src/task/AutoCombatTask.py
@@ -56,9 +56,16 @@ class AutoCombatTask(BaseCombatTask, TriggerTask):
         combat_start = time.time()
         while self.in_combat():
             ret = True
+            current_char = None
             try:
-                self.get_current_char().perform()
+                current_char = self.get_current_char()
+                current_char.perform()
             except CharDeadException:
+                if self.try_continue_after_char_dead(current_char):
+                    continue
+                if self.revive_all_dead_characters():
+                    self.log_info('all characters revived, continue current auto combat loop')
+                    continue
                 self.log_error(f'Characters dead', notify=True)
                 break
             except NotInCombatException as e:

--- a/src/task/BaseCombatTask.py
+++ b/src/task/BaseCombatTask.py
@@ -50,6 +50,15 @@ class BaseCombatTask(CombatCheck):
     hot_key_verified = False  # 热键是否已验证
     con_full_size = None  # 不同角色协奏值充满时的大小记录
     freeze_durations = []  # 记录冻结/卡肉的持续时间
+    char_dead_vote_threshold = 2
+    char_alive_vote_threshold = 2
+    dead_low_saturation_threshold = 0.72
+    alive_low_saturation_threshold = 0.62
+    dead_gray_ratio_threshold = 0.55
+    alive_gray_ratio_threshold = 0.45
+    char_alive_check_interval = 0.5
+    team_revive_button = (0.5, 0.86)
+    team_revive_timeout = 70
     if con_full_size is None:
         con_full_size = Config("_con_full_size", {
             "0": 0,
@@ -73,9 +82,21 @@ class BaseCombatTask(CombatCheck):
         self.mouse_pos = None  # 当前鼠标位置
         self.combat_start = 0  # 战斗开始时间戳
 
+        self.reset_char_alive_states()
         self.char_texts = ['char_1_text', 'char_2_text', 'char_3_text']
         self.add_text_fix({'Ｅ': 'e'})
         self.use_liberation = True
+
+    def reset_char_alive_states(self):
+        self.char_alive_state = [True, True, True]
+        self.char_dead_votes = [0, 0, 0]
+        self.char_alive_votes = [0, 0, 0]
+        self.last_char_alive_check = 0
+
+    def do_reset_to_false(self):
+        ret = super().do_reset_to_false()
+        self.reset_char_alive_states()
+        return ret
 
     def add_freeze_duration(self, start, duration=-1.0, freeze_time=0.1):
         """添加冻结持续时间。用于精确计算技能冷却等。
@@ -342,7 +363,13 @@ class BaseCombatTask(CombatCheck):
         try:
             while self.in_combat():
                 logger.debug(f'combat_once loop {self.chars}')
-                self.get_current_char().perform()
+                current_char = self.get_current_char()
+                try:
+                    current_char.perform()
+                except CharDeadException as e:
+                    if self.try_continue_after_char_dead(current_char):
+                        continue
+                    raise e
         except CharDeadException as e:
             raise e
         except NotInCombatException as e:
@@ -458,9 +485,10 @@ class BaseCombatTask(CombatCheck):
         return self._switch_rule_3_target(candidates)
 
     def _choose_switch_target(self, current_char, has_intro, target_low_con=False):
+        self.update_char_alive_states()
         candidates = [
             char for char in self.chars
-            if char is not None and char != current_char
+            if char is not None and char != current_char and self.is_char_alive(char)
         ]
         if not candidates:
             return current_char
@@ -498,6 +526,168 @@ class BaseCombatTask(CombatCheck):
     def _apply_intro_flags(self, current_char, switch_to, has_intro):
         switch_to.has_intro = has_intro
         switch_to.has_sub_dps_intro = has_intro and current_char.is_sub_dps
+
+    def _ensure_char_alive_state(self):
+        if not hasattr(self, 'char_alive_state'):
+            self.reset_char_alive_states()
+
+    def is_char_alive(self, char):
+        self._ensure_char_alive_state()
+        return char is None or char.index >= len(self.char_alive_state) or self.char_alive_state[char.index]
+
+    def set_char_alive(self, char, alive):
+        self._ensure_char_alive_state()
+        if char is None or char.index >= len(self.char_alive_state):
+            return
+        self.char_alive_state[char.index] = alive
+        message = f'set char alive: {char} index={char.index} alive={alive}'
+        if hasattr(self, 'log_info'):
+            self.log_info(message)
+        else:
+            logger.info(message)
+
+    def _char_portrait_liveness(self, char):
+        try:
+            box = self.get_box_by_name(f'box_char_{char.index + 1}')
+            cropped = box.crop_frame(self.frame)
+        except Exception as e:
+            logger.debug(f'char portrait liveness skipped: {char} {e}')
+            return None
+        if cropped is None or cropped.size == 0:
+            return None
+
+        h, w = cropped.shape[:2]
+        cropped = cropped[int(h * 0.10):int(h * 0.90), int(w * 0.10):int(w * 0.90)]
+        if cropped.size == 0:
+            return None
+
+        hsv = cv2.cvtColor(cropped, cv2.COLOR_BGR2HSV)
+        saturation = hsv[:, :, 1]
+        brightness = hsv[:, :, 2]
+        valid = brightness > 25
+        valid_count = int(valid.sum())
+        if valid_count <= 0:
+            return None
+
+        low_saturation_ratio = float(((saturation < 35) & valid).sum() / valid_count)
+        b, g, r = cv2.split(cropped.astype(np.int16))
+        gray_like = (np.abs(r - g) < 12) & (np.abs(g - b) < 12) & (np.abs(r - b) < 12) & valid
+        gray_ratio = float(gray_like.sum() / valid_count)
+
+        dead = (low_saturation_ratio >= self.dead_low_saturation_threshold and
+                gray_ratio >= self.dead_gray_ratio_threshold)
+        alive = (low_saturation_ratio <= self.alive_low_saturation_threshold or
+                 gray_ratio <= self.alive_gray_ratio_threshold)
+        logger.debug(
+            f'char liveness {char} low_sat={low_saturation_ratio:.2f} gray={gray_ratio:.2f} '
+            f'dead={dead} alive={alive}')
+        return dead, alive
+
+    def update_char_alive_states(self):
+        self._ensure_char_alive_state()
+        if not hasattr(self, 'frame') or self.frame is None:
+            return
+        now = time.time()
+        if now - self.last_char_alive_check < self.char_alive_check_interval:
+            return
+        self.last_char_alive_check = now
+        current_index = -1
+        try:
+            in_team, current_index, _ = self.in_team()
+            if not in_team:
+                current_index = -1
+        except Exception as e:
+            logger.debug(f'char alive current index skipped: {e}')
+        for char in self.chars:
+            if char is None or char.index >= len(self.char_alive_state):
+                continue
+            if char.index == current_index:
+                continue
+            result = self._char_portrait_liveness(char)
+            if result is None:
+                continue
+            dead, alive = result
+            if dead:
+                self.char_dead_votes[char.index] += 1
+                self.char_alive_votes[char.index] = 0
+                if self.char_dead_votes[char.index] >= self.char_dead_vote_threshold:
+                    self.set_char_alive(char, False)
+            elif alive:
+                self.char_alive_votes[char.index] += 1
+                self.char_dead_votes[char.index] = 0
+                if self.char_alive_votes[char.index] >= self.char_alive_vote_threshold:
+                    self.set_char_alive(char, True)
+
+    def has_alive_switch_target(self, current_char=None):
+        self.update_char_alive_states()
+        return any(
+            char is not None and char != current_char and self.is_char_alive(char)
+            for char in self.chars
+        )
+
+    def close_revive_prompt(self):
+        if not self.wait_feature('revive_confirm_hcenter_vcenter', threshold=0.8,
+                                 time_out=0.2, raise_if_not_found=False):
+            return False
+        self.send_key('esc', after_sleep=0.2)
+        return True
+
+    def revive_all_dead_characters(self):
+        """全员死亡时点击免费复苏，并等待角色回到大世界队伍态。"""
+        if not self.wait_feature('revive_confirm_hcenter_vcenter', threshold=0.8,
+                                 time_out=2, raise_if_not_found=False):
+            return False
+
+        self.log_info('all characters dead, waiting for team revive')
+        start = time.time()
+        while time.time() - start < self.team_revive_timeout:
+            if self.in_team_and_world():
+                self.reset_char_alive_states()
+                self.scene.set_not_in_combat()
+                self.info_set('Revive', 'Success')
+                return True
+            self.click(*self.team_revive_button, after_sleep=0.5)
+            if self.wait_in_team_and_world(time_out=1, raise_if_not_found=False):
+                self.reset_char_alive_states()
+                self.scene.set_not_in_combat()
+                self.info_set('Revive', 'Success')
+                return True
+
+        self.log_error('team revive timed out', notify=True)
+        self.info_set('Revive', 'Failed')
+        return False
+
+    def try_continue_after_char_dead(self, current_char):
+        self.set_char_alive(current_char, False)
+        if not self.has_alive_switch_target(current_char):
+            return False
+        self.close_revive_prompt()
+        target = self._choose_switch_target(current_char, has_intro=False)
+        if not target or target == current_char:
+            return False
+        self.send_key(target.index + 1, after_sleep=0.2)
+        if self.wait_until(lambda: self.in_team()[0] and self.in_team()[1] == target.index,
+                           time_out=2, raise_if_not_found=False):
+            for char in self.chars:
+                if char:
+                    char.is_current_char = (char == target)
+            target.last_switch_in_time = time.time()
+            self.scene.set_in_combat()
+            return True
+        return False
+
+    def handle_dead_switch_target(self, current_char, switch_to, has_intro, target_low_con=False):
+        if not self.close_revive_prompt():
+            return None
+        self.set_char_alive(switch_to, False)
+        if not self.has_alive_switch_target(current_char):
+            return None
+        next_target = self._choose_switch_target(current_char, has_intro, target_low_con=target_low_con)
+        if not next_target or next_target == current_char:
+            return None
+        self._apply_intro_flags(current_char, next_target, has_intro)
+        self.log_info(f'skip dead switch target {switch_to}, retry with {next_target}')
+        return next_target
 
     def switch_next_char(self, current_char, post_action=None, free_intro=False, target_low_con=False):
         """切换到下一个最优角色。
@@ -569,6 +759,14 @@ class BaseCombatTask(CombatCheck):
             in_team, current_index, size = self.in_team()
             if not in_team:
                 logger.info(f'not in team while switching chars_{current_char}_to_{switch_to} {now - start}')
+                next_target = self.handle_dead_switch_target(current_char, switch_to, has_intro,
+                                                             target_low_con=target_low_con)
+                if next_target:
+                    switch_to = next_target
+                    start = time.time()
+                    last_click = 0
+                    self.next_frame()
+                    continue
                 # if self.debug:
                 #     self.screenshot(f'not in team while switching chars_{current_char}_to_{switch_to} {now - start}')
                 self.raise_not_in_combat(f'not in_team while switching')

--- a/tests/TestChar.py
+++ b/tests/TestChar.py
@@ -16,7 +16,7 @@ from src.char.Phrolova import Phrolova
 from src.char.Rebecca import Rebecca
 from src.char.ShoreKeeper import ShoreKeeper
 from src.char.Verina import Verina
-from src.task.BaseCombatTask import NotInCombatException
+from src.task.BaseCombatTask import NotInCombatException, CharDeadException
 from src.task.AutoCombatTask import AutoCombatTask
 
 config['debug'] = True
@@ -169,6 +169,108 @@ class TestChar(TaskTestCase):
         combat._apply_intro_flags(healer, current, True)
         self.assertTrue(current.has_intro)
         self.assertFalse(current.has_sub_dps_intro)
+
+    def test_switch_target_skips_dead_char_and_allows_recovered_char(self):
+        class Task:
+            def time_elapsed_accounting_for_freeze(self, start, intro_motion_freeze=False):
+                if start < 0:
+                    return 10000
+                return time.time() - start
+
+        task = Task()
+        combat = AutoCombatTask.__new__(AutoCombatTask)
+        current = BaseChar(task, 0, char_type=CharType.MAIN_DPS)
+        healer = BaseChar(task, 1, char_type=CharType.HEALER)
+        sub_dps = BaseChar(task, 2, char_type=CharType.SUB_DPS)
+        combat.chars = [current, healer, sub_dps]
+        combat.char_alive_state = [True, False, True]
+        combat.char_dead_votes = [0, 0, 0]
+        combat.char_alive_votes = [0, 0, 0]
+        combat.log_info = lambda *args, **kwargs: None
+
+        self.assertEqual(combat._choose_switch_target(current, False), sub_dps)
+
+        combat.set_char_alive(healer, True)
+        self.assertEqual(combat._choose_switch_target(current, False), healer)
+
+    def test_all_dead_revive_clicks_button_and_resets_states(self):
+        class Scene:
+            def __init__(self):
+                self.not_in_combat = False
+
+            def set_not_in_combat(self):
+                self.not_in_combat = True
+
+        combat = AutoCombatTask.__new__(AutoCombatTask)
+        combat.scene = Scene()
+        combat.char_alive_state = [False, False, False]
+        combat.char_dead_votes = [2, 2, 2]
+        combat.char_alive_votes = [0, 0, 0]
+        combat.clicks = []
+        combat.info = []
+        combat.wait_feature = lambda *args, **kwargs: True
+        combat.in_team_and_world = lambda: False
+        combat.click = lambda x, y, **kwargs: combat.clicks.append((x, y))
+        combat.wait_in_team_and_world = lambda **kwargs: True
+        combat.log_info = lambda *args, **kwargs: None
+        combat.log_error = lambda *args, **kwargs: None
+        combat.info_set = lambda key, value: combat.info.append((key, value))
+
+        self.assertTrue(combat.revive_all_dead_characters())
+        self.assertEqual(combat.clicks, [combat.team_revive_button])
+        self.assertEqual(combat.char_alive_state, [True, True, True])
+        self.assertTrue(combat.scene.not_in_combat)
+        self.assertIn(('Revive', 'Success'), combat.info)
+
+    def test_all_dead_revive_requires_death_popup(self):
+        combat = AutoCombatTask.__new__(AutoCombatTask)
+        combat.wait_feature = lambda *args, **kwargs: False
+        combat.click = lambda *args, **kwargs: self.fail('revive button should not be clicked')
+
+        self.assertFalse(combat.revive_all_dead_characters())
+
+    def test_auto_combat_continues_after_all_dead_revive(self):
+        class Scene:
+            @staticmethod
+            def in_team(check):
+                return True
+
+        class CurrentChar:
+            def __init__(self):
+                self.perform_calls = 0
+
+            def perform(self):
+                self.perform_calls += 1
+                if self.perform_calls == 1:
+                    raise CharDeadException('dead')
+                raise NotInCombatException('done')
+
+        combat = AutoCombatTask.__new__(AutoCombatTask)
+        combat.scene = Scene()
+        combat.config = {'Use Liberation': True}
+        combat.warm_up_char_features = lambda: None
+        combat.in_world = lambda: True
+        combat.in_combat = lambda: True
+        combat.in_team_and_world = lambda: True
+        current_char = CurrentChar()
+        combat.get_current_char = lambda: current_char
+        combat.try_continue_after_char_dead = lambda current: False
+        combat.revive_calls = 0
+
+        def revive():
+            combat.revive_calls += 1
+            return True
+
+        combat.revive_all_dead_characters = revive
+        combat.log_info = lambda *args, **kwargs: None
+        combat.log_error = lambda *args, **kwargs: None
+        combat.combat_end_calls = 0
+        combat.combat_end = lambda: setattr(combat, 'combat_end_calls', combat.combat_end_calls + 1)
+
+        self.assertTrue(combat.run())
+        self.assertEqual(combat.revive_calls, 1)
+        self.assertEqual(current_char.perform_calls, 2)
+        self.assertEqual(combat.combat_end_calls, 1)
 
     def test_chisa_support_intro_records_buff_and_switches_immediately(self):
         class Task:


### PR DESCRIPTION
## 修改内容
- 记录队伍角色存活状态，切人候选过滤已死亡角色
- 当前角色死亡时优先切换到仍存活的队友，避免直接中断自动战斗
- 切人过程中遇到复苏弹窗时标记目标死亡并重新选择可用目标
- 全员死亡时点击队伍复苏按钮，复苏成功后继续当前自动战斗循环，让任务继续磨完战斗

## 验证
- python -m py_compile src/task/AutoCombatTask.py src/task/BaseCombatTask.py tests/TestChar.py
- python -m unittest tests.TestChar.TestChar.test_switch_target_skips_dead_char_and_allows_recovered_char tests.TestChar.TestChar.test_all_dead_revive_clicks_button_and_resets_states tests.TestChar.TestChar.test_all_dead_revive_requires_death_popup tests.TestChar.TestChar.test_auto_combat_continues_after_all_dead_revive

## 说明
- 完整 tests.TestChar 当前会因为缺少 ok_templates/char_iuno.png 在既有 test_switch_cd 上失败，与本次修改无关。