### PR TITLE
修复琳奈轮滑模式识别不稳定

### DIFF
--- a/src/char/Linnai.py
+++ b/src/char/Linnai.py
@@ -3,6 +3,10 @@ import time
 from src.char.BaseChar import BaseChar, SwitchPriority, forte_white_color
 
 class Linnai(BaseChar):
+    RES_CHECK_THRESHOLD = 0.6
+    INTRO_RES_WAIT = 1.0
+    AEMEATH_INTRO_RES_WAIT = 1.6
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.last_heavy = 0
@@ -42,7 +46,7 @@ class Linnai(BaseChar):
         return self.switch_next_char()
             
     def perform_under_intro(self):
-        if not self.check_res():
+        if not self.wait_for_accelerate_ready():
             self.logger.debug(f'Linnai fails entering accelerate mode!')
             return False
         self.task.wait_until(lambda: self.is_color_full() or self.is_con_full(), post_action=self.click,
@@ -73,12 +77,42 @@ class Linnai(BaseChar):
         self.sleep(0.3)
         self.wait_down()
 
+    def wait_for_accelerate_ready(self):
+        """等待琳奈入场后的目标状态稳定，避免特效遮挡导致一帧误判。"""
+        if self.check_res():
+            return True
+        time_out = self.INTRO_RES_WAIT
+        if self.has_intro and self.check_outro() in {'char_aemeath'}:
+            time_out = self.AEMEATH_INTRO_RES_WAIT
+        return self.task.wait_until(self.check_res, post_action=self.click_with_interval, time_out=time_out)
+
+    def get_target_names(self):
+        if hasattr(self.task, 'get_target_names'):
+            return self.task.get_target_names()
+        return 'has_target', 'no_target'
+
+    def find_target_status_in_box(self, box_name):
+        try:
+            box = self.task.get_box_by_name(box_name)
+            return self.task.find_best_match_in_box(box, list(self.get_target_names()),
+                                                    threshold=self.RES_CHECK_THRESHOLD)
+        except Exception as e:
+            self.logger.debug(f'Linnai check res skipped {box_name}: {e}')
+            return None
+
     def check_res(self):
         if not self.task.in_team_and_world():
             return False
-        best = self.task.find_best_match_in_box(self.task.get_box_by_name('target_box_long2'),
-                                               ['has_target', 'no_target'],
-                                               threshold=0.6)
+
+        best = self.find_target_status_in_box('target_box_long2')
+        if not best:
+            best = self.find_target_status_in_box('box_target_enemy_long')
+        if not best:
+            try:
+                best = self.task.find_one('target_box_short', threshold=self.RES_CHECK_THRESHOLD)
+            except Exception as e:
+                self.logger.debug(f'Linnai check res skipped target_box_short: {e}')
+                best = None
         self.logger.debug(f'check res {best}')
         return best
 

--- a/tests/TestChar.py
+++ b/tests/TestChar.py
@@ -937,6 +937,68 @@ class TestChar(TaskTestCase):
         self.assertEqual(linnai.actions, [('sleep', 0.3), ('wait_down', True),
                                           ('sleep', 0.3), ('wait_down', True)])
 
+    def test_linnai_waits_longer_after_aemeath_outro(self):
+        class Task:
+            def __init__(self):
+                self.wait_time_out = None
+
+            def wait_until(self, condition, post_action=None, time_out=0, **kwargs):
+                self.wait_time_out = time_out
+                return condition()
+
+        class TestLinnai(Linnai):
+            def __init__(self, task):
+                super().__init__(task, 0)
+                self.has_intro = True
+                self.check_count = 0
+
+            def check_res(self):
+                self.check_count += 1
+                return self.check_count >= 2
+
+            def check_outro(self):
+                return 'char_aemeath'
+
+            def click_with_interval(self, interval=0.1):
+                pass
+
+        task = Task()
+        linnai = TestLinnai(task)
+        self.assertTrue(linnai.wait_for_accelerate_ready())
+        self.assertEqual(task.wait_time_out, linnai.AEMEATH_INTRO_RES_WAIT)
+
+    def test_linnai_check_res_falls_back_to_long_target_box(self):
+        class Box:
+            def __init__(self, name):
+                self.name = name
+
+        class Match:
+            name = 'has_target'
+
+        class Task:
+            def in_team_and_world(self):
+                return True
+
+            def get_target_names(self):
+                return 'has_target', 'no_target'
+
+            def get_box_by_name(self, name):
+                return Box(name)
+
+            def find_best_match_in_box(self, box, names, threshold=0.6):
+                if box.name == 'box_target_enemy_long':
+                    return Match()
+                return None
+
+            def find_one(self, *args, **kwargs):
+                return None
+
+            def time_elapsed_accounting_for_freeze(self, start, intro_motion_freeze=False):
+                return 999
+
+        linnai = Linnai(Task(), 0)
+        self.assertTrue(linnai.check_res())
+
     def test_intro_does_not_switch_to_phrolova_during_liberation_lock(self):
         class Task:
             name = None


### PR DESCRIPTION
## 修改内容
- 琳奈进入轮滑/加速模式前，增加短暂等待，避免入场后目标状态 UI 尚未稳定时直接判定失败。
- 对爱弥斯退场进入琳奈的情况放宽等待时间，降低特效、动画或丢帧导致识别失败的概率。
- `check_res()` 增加目标框兜底识别：`target_box_long2` 失败后继续检查 `box_target_enemy_long` 和 `target_box_short`。

## 测试
- `python -m py_compile src\\char\\Linnai.py tests\\TestChar.py`
- `python -m unittest tests.TestChar.TestChar.test_linnai_waits_after_resonance_kick tests.TestChar.TestChar.test_linnai_waits_longer_after_aemeath_outro tests.TestChar.TestChar.test_linnai_check_res_falls_back_to_long_target_box`