### PR TITLE
Fix multi-account OCR account matching

### DIFF
--- a/src/task/MultiAccountDailyTask.py
+++ b/src/task/MultiAccountDailyTask.py
@@ -12,6 +12,12 @@ from src.task.MouseResetTask import MouseResetTask
 account_pattern = re.compile(r'\*\*\*\*')
 
 
+def normalize_account_name(account):
+    if not account:
+        return account
+    return account.lower().replace('0', 'o').replace('.con', '.com')
+
+
 class MultiAccountDailyTask(WWOneTimeTask, BaseCombatTask):
 
     def __init__(self, *args, **kwargs):
@@ -26,6 +32,17 @@ class MultiAccountDailyTask(WWOneTimeTask, BaseCombatTask):
         self.all_accounts = set()
         self.support_schedule_task = True
 
+    def _mark_done(self, account):
+        normalized = normalize_account_name(account)
+        if normalized:
+            self.done_set.add(normalized)
+
+    def _is_done(self, account):
+        return normalize_account_name(account) in self.done_set
+
+    def _same_account(self, left, right):
+        return normalize_account_name(left) == normalize_account_name(right)
+
     def run(self):
         WWOneTimeTask.run(self)
         self.done_set.clear()
@@ -35,15 +52,14 @@ class MultiAccountDailyTask(WWOneTimeTask, BaseCombatTask):
         self.ensure_main(time_out=100)
         self._switch_to_login()
         detected = self._detect_current_account_from_login()
-        if detected:
-            self.done_set.add(detected)
+        self._mark_done(detected)
 
         self.info_set('Completed', self.done_set)
 
         while next_account := self._select_and_login_account():
             self.info_set('Completed', self.done_set)
             self.run_task_by_class(DailyTask)
-            self.done_set.add(next_account)
+            self._mark_done(next_account)
             self.ensure_main(time_out=100)
             self._switch_to_login()
 
@@ -74,9 +90,9 @@ class MultiAccountDailyTask(WWOneTimeTask, BaseCombatTask):
         next_account = None
         # self.screenshot('_click_account_in_list')
         for account in accounts:
-            self.all_accounts.add(account.name)
+            self.all_accounts.add(normalize_account_name(account.name))
             self.info_set('All Accounts', self.all_accounts)
-            if next_account is None and account.name not in self.done_set:
+            if next_account is None and not self._is_done(account.name):
                 next_account = account.name
                 self.click(account, after_sleep=2)
         self.log_info(self.tr('Click next account: {account}').format(account=next_account))
@@ -114,7 +130,7 @@ class MultiAccountDailyTask(WWOneTimeTask, BaseCombatTask):
                 current_account = self._detect_current_account_from_login()
                 self.log_info(self.tr('Selected account: {selected}, displayed account: {displayed}').format(
                     selected=account, displayed=current_account))
-                if account == current_account:
+                if self._same_account(account, current_account):
                     self.log_info(self.tr('Confirmed selected account: {account}').format(account=account))
                     break
                 if attempt < max_retries:

--- a/src/task/MultiAccountDailyTask.py
+++ b/src/task/MultiAccountDailyTask.py
@@ -44,6 +44,8 @@ class MultiAccountDailyTask(WWOneTimeTask, BaseCombatTask):
             self.info_set('Completed', self.done_set)
             self.run_task_by_class(DailyTask)
             self.done_set.add(next_account)
+            self.ensure_main(time_out=100)
+            self._switch_to_login()
 
     def _click_center_offset(self, offset_x, offset_y, after_sleep=0.5):
         h, w = self.frame.shape[:2]

--- a/src/task/MultiAccountDailyTask.py
+++ b/src/task/MultiAccountDailyTask.py
@@ -32,7 +32,7 @@ class MultiAccountDailyTask(WWOneTimeTask, BaseCombatTask):
         self.all_accounts.clear()
 
         self.run_task_by_class(DailyTask)
-        # self.ensure_main(time_out=100)
+        self.ensure_main(time_out=100)
         self._switch_to_login()
         detected = self._detect_current_account_from_login()
         if detected:
@@ -146,13 +146,14 @@ class MultiAccountDailyTask(WWOneTimeTask, BaseCombatTask):
                 mouse_reset_task.enable()
 
     def find_account_drop_down(self):
-        return self.wait_until(self.do_find_account_drop_down, time_out=60, settle_time=2)
+        return self.wait_until(self.do_find_account_drop_down, time_out=60, settle_time=2, raise_if_not_found=True)
 
     def do_find_account_drop_down(self) -> Box | None:
         texts = self.ocr()
-        if len(self.find_boxes(texts, account_pattern)) == 1 and len(self.find_boxes(texts, LOGIN_TEXTS)) == 1:
-            drop_down = self.find_boxes(texts, account_pattern)[0]
-            return drop_down
+        account_boxes = self.find_boxes(texts, account_pattern)
+        login_boxes = self.find_boxes(texts, LOGIN_TEXTS)
+        if len(account_boxes) == 1 and login_boxes:
+            return account_boxes[0]
         return None
 
 

--- a/tests/TestMultiAccountDailyTask.py
+++ b/tests/TestMultiAccountDailyTask.py
@@ -1,0 +1,27 @@
+import unittest
+
+from src.task.BaseWWTask import LOGIN_TEXTS
+from src.task.MultiAccountDailyTask import MultiAccountDailyTask, account_pattern
+
+
+class TestMultiAccountDailyTask(unittest.TestCase):
+
+    def test_account_dropdown_accepts_multiple_login_text_matches(self):
+        account_box = object()
+
+        class FakeTask:
+            def ocr(self):
+                return []
+
+            def find_boxes(self, texts, match):
+                if match == account_pattern:
+                    return [account_box]
+                if match == LOGIN_TEXTS:
+                    return [object(), object()]
+                return []
+
+        self.assertIs(MultiAccountDailyTask.do_find_account_drop_down(FakeTask()), account_box)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/TestMultiAccountDailyTask.py
+++ b/tests/TestMultiAccountDailyTask.py
@@ -1,7 +1,11 @@
 import unittest
 
 from src.task.BaseWWTask import LOGIN_TEXTS
-from src.task.MultiAccountDailyTask import MultiAccountDailyTask, account_pattern
+from src.task.MultiAccountDailyTask import (
+    MultiAccountDailyTask,
+    account_pattern,
+    normalize_account_name,
+)
 
 
 class TestMultiAccountDailyTask(unittest.TestCase):
@@ -21,6 +25,59 @@ class TestMultiAccountDailyTask(unittest.TestCase):
                 return []
 
         self.assertIs(MultiAccountDailyTask.do_find_account_drop_down(FakeTask()), account_box)
+
+    def test_account_name_normalization_groups_common_ocr_variants(self):
+        self.assertEqual(
+            normalize_account_name("cc****33@demo.com.hk"),
+            normalize_account_name("cc****33@dem0.com.hk"),
+        )
+        self.assertEqual(
+            normalize_account_name("bb****02@example.com"),
+            normalize_account_name("bb****02@example.con"),
+        )
+
+    def test_click_account_list_selects_visible_third_account_after_first_two_are_done(self):
+        class AccountBox:
+            def __init__(self, name):
+                self.name = name
+
+        class FakeTask:
+            def __init__(self):
+                self.done_set = {
+                    normalize_account_name("aa****01@example.com"),
+                    normalize_account_name("bb****02@example.com"),
+                }
+                self.all_accounts = set()
+                self.clicked = []
+
+            _is_done = MultiAccountDailyTask._is_done
+
+            def ocr(self, match=None):
+                return [
+                    AccountBox("aa****01@example.com"),
+                    AccountBox("aa****01@example.com"),
+                    AccountBox("bb****02@example.com"),
+                    AccountBox("cc****03@example.com.hk"),
+                ]
+
+            def info_set(self, *args):
+                pass
+
+            def click(self, account, after_sleep=0):
+                self.clicked.append(account.name)
+
+            def log_info(self, *args):
+                pass
+
+            def tr(self, message):
+                return message
+
+        task = FakeTask()
+
+        selected = MultiAccountDailyTask._click_account_in_list(task)
+
+        self.assertEqual(selected, "cc****03@example.com.hk")
+        self.assertEqual(task.clicked, ["cc****03@example.com.hk"])
 
 
 if __name__ == "__main__":

--- a/tests/TestScheduleSupport.py
+++ b/tests/TestScheduleSupport.py
@@ -90,6 +90,25 @@ class TestScheduleSupport(unittest.TestCase):
 
         self.assertIn("ensure_main", call_names[first_daily_index + 1:switch_index])
 
+    def test_multi_account_switches_to_login_after_each_account_daily(self):
+        run_node = _class_function("src/task/MultiAccountDailyTask.py", "MultiAccountDailyTask", "run")
+        while_node = next(node for node in ast.walk(run_node) if isinstance(node, ast.While))
+
+        calls = [
+            node for node in ast.walk(while_node)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "self"
+            and node.func.attr in {"run_task_by_class", "ensure_main", "_switch_to_login"}
+        ]
+
+        call_names = [node.func.attr for node in sorted(calls, key=lambda call: call.lineno)]
+        daily_index = call_names.index("run_task_by_class")
+
+        self.assertIn("ensure_main", call_names[daily_index + 1:])
+        self.assertIn("_switch_to_login", call_names[daily_index + 1:])
+
     def test_multi_account_login_dropdown_timeout_is_not_silent(self):
         find_node = _class_function(
             "src/task/MultiAccountDailyTask.py",

--- a/tests/TestScheduleSupport.py
+++ b/tests/TestScheduleSupport.py
@@ -11,6 +11,18 @@ TASK_FILES = {
 }
 
 
+def _class_function(module_path, class_name, function_name):
+    module = ast.parse(Path(module_path).read_text(encoding="utf-8"))
+    class_node = next(
+        node for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == class_name
+    )
+    return next(
+        node for node in class_node.body
+        if isinstance(node, ast.FunctionDef) and node.name == function_name
+    )
+
+
 class TestScheduleSupport(unittest.TestCase):
 
     def test_selected_tasks_enable_schedule_support(self):
@@ -47,15 +59,7 @@ class TestScheduleSupport(unittest.TestCase):
                 self.assertTrue(has_schedule_assignment, file_path.as_posix())
 
     def test_tacet_task_run_handles_login_before_entering_world(self):
-        module = ast.parse(Path("src/task/TacetTask.py").read_text(encoding="utf-8"))
-        class_node = next(
-            node for node in module.body
-            if isinstance(node, ast.ClassDef) and node.name == "TacetTask"
-        )
-        run_node = next(
-            node for node in class_node.body
-            if isinstance(node, ast.FunctionDef) and node.name == "run"
-        )
+        run_node = _class_function("src/task/TacetTask.py", "TacetTask", "run")
 
         ensure_main_calls = [
             node for node in ast.walk(run_node)
@@ -67,6 +71,45 @@ class TestScheduleSupport(unittest.TestCase):
         ]
 
         self.assertTrue(ensure_main_calls)
+
+    def test_multi_account_returns_to_main_before_switching_to_login(self):
+        run_node = _class_function("src/task/MultiAccountDailyTask.py", "MultiAccountDailyTask", "run")
+
+        calls = [
+            node for node in ast.walk(run_node)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "self"
+            and node.func.attr in {"run_task_by_class", "ensure_main", "_switch_to_login"}
+        ]
+
+        call_names = [node.func.attr for node in sorted(calls, key=lambda call: call.lineno)]
+        first_daily_index = call_names.index("run_task_by_class")
+        switch_index = call_names.index("_switch_to_login")
+
+        self.assertIn("ensure_main", call_names[first_daily_index + 1:switch_index])
+
+    def test_multi_account_login_dropdown_timeout_is_not_silent(self):
+        find_node = _class_function(
+            "src/task/MultiAccountDailyTask.py",
+            "MultiAccountDailyTask",
+            "find_account_drop_down",
+        )
+
+        wait_until = next(
+            node for node in ast.walk(find_node)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "self"
+            and node.func.attr == "wait_until"
+        )
+        raise_kw = next((kw for kw in wait_until.keywords if kw.arg == "raise_if_not_found"), None)
+
+        self.assertIsNotNone(raise_kw)
+        self.assertIsInstance(raise_kw.value, ast.Constant)
+        self.assertIs(raise_kw.value.value, True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# PR 说明 / PR Description

  ## 修改内容 / Changes

  - 修复多账号每日任务中，账号名 OCR 偶发误识别导致已完成账号被重复选择、后续账号无法稳定切换的问题。
  - 对账号名比较增加轻量归一化处理，用于处理常见 OCR 误读，例如 `0/o`、`.con/.com`。
  - 将已完成账号记录、账号列表选择、选中账号确认统一改为使用归一化后的账号名比较。
  - 增加单元测试覆盖常见 OCR 误读，以及 3 个账号同屏可见时前 2 个已完成后应选择第 3 个账号的场景。

  ## 修改类型 / Type of Change

  - [x] Bug 修复 / Bug fix
  - [ ] 文档或翻译 / Documentation or translation
  - [x] 小型优化或兼容性修复 / Small improvement or compatibility fix
  - [ ] 新功能 / New feature
  - [ ] 大幅修改现有功能 / Major modification of existing behavior
  - [ ] 重构或架构调整 / Refactor or architecture change

  ## 新功能或大改确认 / New Feature or Major Change Confirmation

  - [x] 不适用，本 PR 不是新功能或大改 / Not applicable; this PR is not a new feature or major change
  - [ ] 已联系作者或已在社区讨论 / I have contacted the author or discussed this in the community

  相关讨论链接或联系方式说明：

  - 不适用 / Not applicable

  ## 测试 / Testing

  - 已运行 / Ran:
    `.\.venv\Scripts\python.exe -m unittest tests.TestMultiAccountDailyTask tests.TestScheduleSupport`
  - 结果 / Result:
    `Ran 8 tests in 0.009s`
    `OK`
  - 已进行实机验证：多账号每日任务在前两个账号完成后，可以从同屏可见的账号列表中选择第 3 个账号，并成功进入登录流程。
  - 确认测试文件仅使用示例账号数据，没有提交日志、截图或个人账号信息。

  ## 截图或录屏 / Screenshots or Recordings

  - 将在 PR 中补充截图或录屏。 / Screenshot or recording will be attached separately.

  ## 检查清单 / Checklist

  - [x] 我已阅读 [CONTRIBUTING.md](https://github.com/ok-oldking/ok-wuthering-waves/blob/master/CONTRIBUTING.md) / I have read [CONTRIBUTING.md](https://github.com/ok-oldking/ok-wuthering-waves/blob/master/CONTRIBUTING.md)
  - [x] 我已阅读 README 中的免责声明 / I have read the disclaimer in the README
  - [x] 我已尽量保持 PR 范围清晰，没有混入无关修改 / I have kept this PR focused and avoided unrelated changes
  - [x] 我已说明测试结果或无法测试的原因 / I have described the test results or why testing was not possible
  - [x] 我没有提交日志、缓存、临时文件或个人配置 / I have not committed logs, caches, temporary files, or personal settings

  ## 社区联系方式 / Community Contact

  - 开发者群 / Developer QQ group: `926858895`
  - Discord: [https://discord.gg/vVyCatEBgA](https://discord.gg/vVyCatEBgA)
<img width="2551" height="1435" alt="QQ图片20260627150123" src="https://github.com/user-attachments/assets/f9be9e10-b09f-4531-830b-2adf59dfcf6f" />
