### PR TITLE
为 DomainTask.make_sure_in_world 的 wait_click_feature 加入 after_sleep

### DIFF
--- a/src/task/DomainTask.py
+++ b/src/task/DomainTask.py
@@ -44,7 +44,7 @@ class DomainTask(WWOneTimeTask, BaseCombatTask):
         if self.in_realm():
             self.send_key('esc', after_sleep=1)
             self.wait_click_feature('gray_confirm_exit_button', relative_x=-1, raise_if_not_found=False,
-                                    time_out=3, click_after_delay=0.5, threshold=0.7)
+                                    time_out=3, click_after_delay=0.5, threshold=0.7, after_sleep=1)
             self.wait_in_team_and_world(time_out=self.teleport_timeout)
         else:
             self.ensure_main()


### PR DESCRIPTION
# PR 说明 / PR Description

## 修改内容 / Changes

请简要说明本 PR 修改了什么。

为 `DomainTask.make_sure_in_world` 的 `wait_click_feature` 加入 after_sleep 。

修改原因：

wait_click_feature 点击后有若干帧（极短时间），角色仍然处于大世界（尚未开始加载）。这会导致下一指令 `wait_in_team_and_world` （借助侧边角色状态来判断大世界）立即返回而不是等待加载完毕。因此需要 after_sleep 来确保 `wait_in_team_and_world` 执行时处于加载中。

## 修改类型 / Type of Change

请选择适用项：

Please check all that apply:

- [x] Bug 修复 / Bug fix
- [ ] 文档或翻译 / Documentation or translation
- [ ] 小型优化或兼容性修复 / Small improvement or compatibility fix
- [ ] 新功能 / New feature
- [ ] 大幅修改现有功能 / Major modification of existing behavior
- [ ] 重构或架构调整 / Refactor or architecture change

## 新功能或大改确认 / New Feature or Major Change Confirmation

如果本 PR 包含新功能，或会大幅修改当前功能、任务行为、角色逻辑、识别逻辑、配置结构或用户体验，请先联系作者或在社区中讨论后再提交。

If this PR adds a new feature, or significantly changes existing features, task behavior, character logic, recognition logic, configuration structure, or user experience, please contact the author or discuss it with the community before submitting.

- [x] 不适用，本 PR 不是新功能或大改 / Not applicable; this PR is not a new feature or major change
- [ ] 已联系作者或已在社区讨论 / I have contacted the author or discussed this in the community

相关讨论链接或联系方式说明：

Related discussion link or contact note:

## 检查清单 / Checklist

- [x] 我已阅读 [CONTRIBUTING.md](https://github.com/ok-oldking/ok-wuthering-waves/blob/master/CONTRIBUTING.md) / I have read [CONTRIBUTING.md](https://github.com/ok-oldking/ok-wuthering-waves/blob/master/CONTRIBUTING.md)
- [x] 我已阅读 README 中的免责声明 / I have read the disclaimer in the README
- [x] 我已尽量保持 PR 范围清晰，没有混入无关修改 / I have kept this PR focused and avoided unrelated changes
- [x] 我已说明测试结果或无法测试的原因 / I have described the test results or why testing was not possible
- [x] 我没有提交日志、缓存、临时文件或个人配置 / I have not committed logs, caches, temporary files, or personal settings

## 社区联系方式 / Community Contact

- 开发者群 / Developer QQ group: `926858895`
- Discord: [https://discord.gg/vVyCatEBgA](https://discord.gg/vVyCatEBgA)
