### PR TITLE
增加固定轴队伍轮换

### DIFF
--- a/src/char/Cartethyia.py
+++ b/src/char/Cartethyia.py
@@ -1,7 +1,7 @@
 import time, cv2
 import numpy as np
 from src.char.BaseChar import BaseChar, SwitchPriority, forte_white_color
-from src.char.TeamRotations import advance_cqc_phase, get_cqc_phase
+from src.char.TeamRotations import get_cqc_phase, get_rotation_switch_priority, perform_rotation_phase, advance_cqc_phase
 
 
 class Cartethyia(BaseChar):
@@ -50,12 +50,9 @@ class Cartethyia(BaseChar):
             self.logger.debug(f'on_combat_end {self.index} switch end')
 
     def get_switch_priority(self, current_char=None, has_intro=False, target_low_con=False):
-        phase = get_cqc_phase(self.task)
-        if phase is not None:
-            expected_char, _ = phase
-            if expected_char == self.__class__.__name__:
-                return SwitchPriority.MUST
-            return SwitchPriority.NO
+        priority = get_rotation_switch_priority(self, get_cqc_phase)
+        if priority is not None:
+            return priority
         if not self.is_cartethyia:
             return SwitchPriority.MUST
         return super().get_switch_priority(current_char, has_intro, target_low_con)
@@ -102,18 +99,7 @@ class Cartethyia(BaseChar):
         self.switch_next_char()
 
     def cartethyia_qiuyuan_chisa_rotation(self):
-        phase = get_cqc_phase(self.task)
-        if phase is None:
-            return False
-        expected_char, action = phase
-        if expected_char != self.__class__.__name__:
-            self.switch_next_char()
-            return True
-        self.wait_down()
-        getattr(self, action)()
-        advance_cqc_phase(self.task)
-        self.switch_next_char()
-        return True
+        return perform_rotation_phase(self, get_cqc_phase, advance_cqc_phase, wait_down=True)
 
     def cqc_cart_e_r_e_e(self):
         self.click_resonance_with_lib_big()

--- a/src/char/Cartethyia.py
+++ b/src/char/Cartethyia.py
@@ -71,7 +71,9 @@ class Cartethyia(BaseChar):
         if self.is_small():
             self.logger.info(f'is cartethyia')
             self.wait_down()
-            if self.acquire_missing_buffs():
+            should_switch = self.acquire_missing_buffs()
+            self.try_mid_air_attack()
+            if should_switch and not self.liberation_available():
                 return self.switch_next_char()
             self.check_combat()
             self.try_mid_air_attack()

--- a/src/char/Cartethyia.py
+++ b/src/char/Cartethyia.py
@@ -1,6 +1,7 @@
 import time, cv2
 import numpy as np
 from src.char.BaseChar import BaseChar, SwitchPriority, forte_white_color
+from src.char.TeamRotations import advance_cqc_phase, get_cqc_phase
 
 
 class Cartethyia(BaseChar):
@@ -49,12 +50,20 @@ class Cartethyia(BaseChar):
             self.logger.debug(f'on_combat_end {self.index} switch end')
 
     def get_switch_priority(self, current_char=None, has_intro=False, target_low_con=False):
+        phase = get_cqc_phase(self.task)
+        if phase is not None:
+            expected_char, _ = phase
+            if expected_char == self.__class__.__name__:
+                return SwitchPriority.MUST
+            return SwitchPriority.NO
         if not self.is_cartethyia:
             return SwitchPriority.MUST
         return super().get_switch_priority(current_char, has_intro, target_low_con)
 
     def do_perform(self):
         self.transform = False
+        if self.cartethyia_qiuyuan_chisa_rotation():
+            return
         if self.has_intro:
             self.continues_normal_attack(1.2)
         else:
@@ -89,6 +98,50 @@ class Cartethyia(BaseChar):
             self.n4_time = time.time()
         self.try_lib_big()
         self.switch_next_char()
+
+    def cartethyia_qiuyuan_chisa_rotation(self):
+        phase = get_cqc_phase(self.task)
+        if phase is None:
+            return False
+        expected_char, action = phase
+        if expected_char != self.__class__.__name__:
+            self.switch_next_char()
+            return True
+        self.wait_down()
+        getattr(self, action)()
+        advance_cqc_phase(self.task)
+        self.switch_next_char()
+        return True
+
+    def cqc_cart_e_r_e_e(self):
+        self.click_resonance_with_lib_big()
+        self.click_echo(time_out=0)
+        self.click_resonance_with_lib_big()
+        self.click_resonance_with_lib_big()
+
+    def cqc_cart_a3_a4(self):
+        self.continues_normal_attack(1.0)
+
+    def cqc_cart_a5_r1(self):
+        self.continues_normal_attack(1.2)
+        self.click_echo(time_out=0)
+
+    def cqc_cart_a3(self):
+        self.continues_normal_attack(0.7)
+
+    def cqc_cart_a4_z_q(self):
+        self.continues_normal_attack(0.9)
+        self.try_mid_air_attack(timeout=1.2)
+        self.click_liberation()
+
+    def cqc_cart_drop_a_z_e3_a_e_e_r(self):
+        self.try_mid_air_attack(timeout=1.6)
+        self.continues_normal_attack(0.25)
+        self.try_mid_air_attack(timeout=1.2)
+        for _ in range(3):
+            self.click_resonance_with_lib_big()
+            self.continues_normal_attack(0.2)
+        self.click_echo(time_out=0)
 
     def fleurdelys_n4_duration(self):
         if not self.transform and self.has_intro:

--- a/src/char/Chisa.py
+++ b/src/char/Chisa.py
@@ -1,7 +1,7 @@
 import time
 
 from src.char.BaseChar import BaseChar, CharType, SwitchPriority, get_default_buff_time
-from src.char.TeamRotations import advance_cqc_phase, get_cqc_phase
+from src.char.TeamRotations import advance_cqc_phase, get_cqc_phase, get_rotation_switch_priority, perform_rotation_phase
 
 
 class Chisa(BaseChar):
@@ -26,19 +26,7 @@ class Chisa(BaseChar):
         return self.do_dps_perform()
 
     def cartethyia_qiuyuan_chisa_rotation(self):
-        phase = get_cqc_phase(self.task)
-        if phase is None:
-            return False
-        expected_char, action = phase
-        if expected_char != self.__class__.__name__:
-            self.switch_next_char()
-            return True
-        if self.flying():
-            self.wait_down()
-        getattr(self, action)()
-        advance_cqc_phase(self.task)
-        self.switch_next_char()
-        return True
+        return perform_rotation_phase(self, get_cqc_phase, advance_cqc_phase, wait_down_if_flying=True)
 
     def cqc_chisa_e(self):
         self.click_resonance(time_out=0.5)
@@ -65,12 +53,9 @@ class Chisa(BaseChar):
         self.continues_normal_attack(0.65)
 
     def get_switch_priority(self, current_char=None, has_intro=False, target_low_con=False):
-        phase = get_cqc_phase(self.task)
-        if phase is not None:
-            expected_char, _ = phase
-            if expected_char == self.__class__.__name__:
-                return SwitchPriority.MUST
-            return SwitchPriority.NO
+        priority = get_rotation_switch_priority(self, get_cqc_phase)
+        if priority is not None:
+            return priority
         return super().get_switch_priority(current_char, has_intro, target_low_con)
 
     def do_fast_support(self):

--- a/src/char/Chisa.py
+++ b/src/char/Chisa.py
@@ -1,6 +1,7 @@
 import time
 
-from src.char.BaseChar import BaseChar, CharType, get_default_buff_time
+from src.char.BaseChar import BaseChar, CharType, SwitchPriority, get_default_buff_time
+from src.char.TeamRotations import advance_cqc_phase, get_cqc_phase
 
 
 class Chisa(BaseChar):
@@ -18,9 +19,59 @@ class Chisa(BaseChar):
         return super().get_buff_time()
 
     def do_perform(self):
+        if self.cartethyia_qiuyuan_chisa_rotation():
+            return
         if not self.is_dps_config():
             return self.do_fast_support()
         return self.do_dps_perform()
+
+    def cartethyia_qiuyuan_chisa_rotation(self):
+        phase = get_cqc_phase(self.task)
+        if phase is None:
+            return False
+        expected_char, action = phase
+        if expected_char != self.__class__.__name__:
+            self.switch_next_char()
+            return True
+        if self.flying():
+            self.wait_down()
+        getattr(self, action)()
+        advance_cqc_phase(self.task)
+        self.switch_next_char()
+        return True
+
+    def cqc_chisa_e(self):
+        self.click_resonance(time_out=0.5)
+
+    def cqc_chisa_a(self):
+        self.continues_normal_attack(0.25)
+
+    def cqc_chisa_a3(self):
+        self.continues_normal_attack(0.65)
+
+    def cqc_chisa_a4(self):
+        self.continues_normal_attack(0.85)
+
+    def cqc_chisa_r_e(self):
+        self.click_echo(time_out=0)
+        self.click_resonance(time_out=0.5)
+
+    def cqc_chisa_z2_dodge_a3(self):
+        if self.is_forte_full():
+            self.perform_forte()
+        else:
+            self.heavy_attack(0.45)
+        self.continues_right_click(0.05)
+        self.continues_normal_attack(0.65)
+
+    def get_switch_priority(self, current_char=None, has_intro=False, target_low_con=False):
+        phase = get_cqc_phase(self.task)
+        if phase is not None:
+            expected_char, _ = phase
+            if expected_char == self.__class__.__name__:
+                return SwitchPriority.MUST
+            return SwitchPriority.NO
+        return super().get_switch_priority(current_char, has_intro, target_low_con)
 
     def do_fast_support(self):
         self.check_f_on_switch = True

--- a/src/char/HavocRover.py
+++ b/src/char/HavocRover.py
@@ -1,5 +1,6 @@
 import time
-from src.char.BaseChar import BaseChar, Elements
+from src.char.BaseChar import BaseChar, Elements, SwitchPriority
+from src.char.TeamRotations import advance_zpr_phase, get_zpr_phase
 
 
 class HavocRover(BaseChar):
@@ -14,6 +15,8 @@ class HavocRover(BaseChar):
         self.init()
         if not self.has_intro:
             self.sleep(0.01)
+        if self.zani_phoebe_rover_rotation():
+            return
         if self.ring_index == Elements.HAVOC:
             self.intro_motion_freeze_duration = 0.64
             self.perform_havoc_routine()
@@ -26,6 +29,46 @@ class HavocRover(BaseChar):
         else:
             self.perform_basic_routine()
         self.switch_next_char()
+
+    def zani_phoebe_rover_rotation(self):
+        phase = get_zpr_phase(self.task)
+        if phase is None:
+            return False
+        expected_char, action = phase
+        if expected_char != self.__class__.__name__:
+            self.switch_next_char()
+            return True
+        self.wait_down()
+        getattr(self, action)()
+        advance_zpr_phase(self.task)
+        self.switch_next_char()
+        return True
+
+    def rover_r(self):
+        self.click_echo(time_out=0)
+
+    def rover_e(self):
+        self.click_resonance(send_click=False, time_out=0.4)
+
+    def rover_e_q(self):
+        self.click_resonance(send_click=False, time_out=0.4)
+        self.click_liberation(send_click=True)
+
+    def rover_a(self):
+        self.continues_normal_attack(0.25)
+
+    def rover_a_z_a(self):
+        self.continues_normal_attack(0.2)
+        self.spectro_routine_aftertune_combo()
+
+    def rover_a_z_a_r(self):
+        self.rover_a_z_a()
+        self.click_echo(time_out=0)
+
+    def rover_a_z_a_e_q(self):
+        self.rover_a_z_a()
+        self.click_resonance(send_click=False, time_out=0.4)
+        self.click_liberation(send_click=True)
 
     def init(self):
         if self.ring_index == -1:
@@ -173,3 +216,12 @@ class HavocRover(BaseChar):
             self.sleep(0.03)
         if self.is_forte_full():
             self.send_resonance_key()
+
+    def get_switch_priority(self, current_char=None, has_intro=False, target_low_con=False):
+        phase = get_zpr_phase(self.task)
+        if phase is not None:
+            expected_char, _ = phase
+            if expected_char == self.__class__.__name__:
+                return SwitchPriority.MUST
+            return SwitchPriority.NO
+        return super().get_switch_priority(current_char, has_intro, target_low_con)

--- a/src/char/HavocRover.py
+++ b/src/char/HavocRover.py
@@ -1,6 +1,6 @@
 import time
 from src.char.BaseChar import BaseChar, Elements, SwitchPriority
-from src.char.TeamRotations import advance_zpr_phase, get_zpr_phase
+from src.char.TeamRotations import advance_zpr_phase, get_zpr_phase, get_rotation_switch_priority, perform_rotation_phase
 
 
 class HavocRover(BaseChar):
@@ -31,18 +31,7 @@ class HavocRover(BaseChar):
         self.switch_next_char()
 
     def zani_phoebe_rover_rotation(self):
-        phase = get_zpr_phase(self.task)
-        if phase is None:
-            return False
-        expected_char, action = phase
-        if expected_char != self.__class__.__name__:
-            self.switch_next_char()
-            return True
-        self.wait_down()
-        getattr(self, action)()
-        advance_zpr_phase(self.task)
-        self.switch_next_char()
-        return True
+        return perform_rotation_phase(self, get_zpr_phase, advance_zpr_phase, wait_down=True)
 
     def rover_r(self):
         self.click_echo(time_out=0)
@@ -218,10 +207,7 @@ class HavocRover(BaseChar):
             self.send_resonance_key()
 
     def get_switch_priority(self, current_char=None, has_intro=False, target_low_con=False):
-        phase = get_zpr_phase(self.task)
-        if phase is not None:
-            expected_char, _ = phase
-            if expected_char == self.__class__.__name__:
-                return SwitchPriority.MUST
-            return SwitchPriority.NO
+        priority = get_rotation_switch_priority(self, get_zpr_phase)
+        if priority is not None:
+            return priority
         return super().get_switch_priority(current_char, has_intro, target_low_con)

--- a/src/char/Phoebe.py
+++ b/src/char/Phoebe.py
@@ -5,7 +5,7 @@ import math
 from enum import Enum
 
 from src.char.BaseChar import BaseChar, SwitchPriority, forte_white_color
-from src.char.TeamRotations import advance_zpr_phase, get_zpr_phase
+from src.char.TeamRotations import advance_zpr_phase, get_zpr_phase, get_rotation_switch_priority, perform_rotation_phase
 from ok import color_range_to_bound
 
 
@@ -89,17 +89,7 @@ class Phoebe(BaseChar):
         self.switch_next_char()
 
     def zani_phoebe_rover_rotation(self):
-        phase = get_zpr_phase(self.task)
-        if phase is None:
-            return False
-        expected_char, action = phase
-        if expected_char != self.__class__.__name__:
-            self.switch_next_char()
-            return True
-        getattr(self, action)()
-        advance_zpr_phase(self.task)
-        self.switch_next_char()
-        return True
+        return perform_rotation_phase(self, get_zpr_phase, advance_zpr_phase)
 
     def phoebe_long_e_r_e_q(self):
         self.wait_down()
@@ -383,12 +373,9 @@ class Phoebe(BaseChar):
         return super().switch_next_char(*args, **kwargs)
 
     def get_switch_priority(self, current_char=None, has_intro=False, target_low_con=False):
-        phase = get_zpr_phase(self.task)
-        if phase is not None:
-            expected_char, _ = phase
-            if expected_char == self.__class__.__name__:
-                return SwitchPriority.MUST
-            return SwitchPriority.NO
+        priority = get_rotation_switch_priority(self, get_zpr_phase)
+        if priority is not None:
+            return priority
         if not has_intro and self.last_outro_time > 0 and self.time_elapsed_accounting_for_freeze(
                 self.last_outro_time, intro_motion_freeze=True) < 4.5:
             self.logger.info('performing outro, switch priority no')

--- a/src/char/Phoebe.py
+++ b/src/char/Phoebe.py
@@ -78,7 +78,7 @@ class Phoebe(BaseChar):
             self.state["liberation"] += 1
             self.check_combat()
         if status_entered == State.SUCCESS or self.judge_forte() > 0:
-            self.starflash_combo()
+            self.starflash_combo_with_setup(status_entered == State.SUCCESS)
         if self.resonance_available():
             if self.attribute == 2:
                 self.click_resonance_once()
@@ -246,6 +246,12 @@ class Phoebe(BaseChar):
             self.continues_right_click(0.05)
         if self.perform_heavy_attack():
             self.state["starflash_combo"] += 1
+
+    def starflash_combo_with_setup(self, status_entered=False):
+        if status_entered and self.star_available and self.judge_forte() == 0:
+            self.continues_normal_attack(0.45)
+            self.continues_right_click(0.05)
+        self.starflash_combo()
 
     def perform_heavy_attack(self):
         if self.absolution_or_confession() == State.UNAVAILABLE:

--- a/src/char/Phoebe.py
+++ b/src/char/Phoebe.py
@@ -5,6 +5,7 @@ import math
 from enum import Enum
 
 from src.char.BaseChar import BaseChar, SwitchPriority, forte_white_color
+from src.char.TeamRotations import advance_zpr_phase, get_zpr_phase
 from ok import color_range_to_bound
 
 
@@ -41,6 +42,8 @@ class Phoebe(BaseChar):
         start = time.time()
         if self.attribute == 0:
             self.decide_teammate()
+        if self.zani_phoebe_rover_rotation():
+            return
         if self.has_intro:
             self.continues_normal_attack(1.5)
         else:
@@ -84,6 +87,74 @@ class Phoebe(BaseChar):
             return self.switch_next_char()
         self.continues_normal_attack(0.1)
         self.switch_next_char()
+
+    def zani_phoebe_rover_rotation(self):
+        phase = get_zpr_phase(self.task)
+        if phase is None:
+            return False
+        expected_char, action = phase
+        if expected_char != self.__class__.__name__:
+            self.switch_next_char()
+            return True
+        getattr(self, action)()
+        advance_zpr_phase(self.task)
+        self.switch_next_char()
+        return True
+
+    def phoebe_long_e_r_e_q(self):
+        self.wait_down()
+        self.absolution_or_confession()
+        self.click_echo(time_out=0)
+        if self.attribute == 2:
+            self.click_resonance_once()
+        else:
+            self.click_resonance(send_click=False, time_out=0.4)
+        if self.click_liberation(send_click=True):
+            self.state["liberation"] += 1
+
+    def phoebe_aaa_dodge_aaa_dodge_aaa_z(self):
+        self.wait_down()
+        self.continues_normal_attack(0.45)
+        self.continues_right_click(0.05)
+        self.continues_normal_attack(0.45)
+        self.continues_right_click(0.05)
+        self.continues_normal_attack(0.45)
+        self.starflash_combo()
+
+    def phoebe_aaa(self):
+        self.wait_down()
+        self.continues_normal_attack(0.45)
+
+    def phoebe_z(self):
+        self.wait_down()
+        self.starflash_combo()
+
+    def phoebe_intro(self):
+        if self.has_intro:
+            self.continues_normal_attack(0.35)
+        else:
+            self.sleep(0.05)
+
+    def phoebe_aaa_dodge_z_dodge_aaa_f(self):
+        self.wait_down()
+        self.continues_normal_attack(0.45)
+        self.continues_right_click(0.05)
+        self.starflash_combo()
+        self.continues_right_click(0.05)
+        self.continues_normal_attack(0.45)
+        self.f_break(check_f_on_switch=True)
+
+    def phoebe_e_dodge_long_e_r_q(self):
+        self.wait_down()
+        if self.attribute == 2:
+            self.click_resonance_once()
+        else:
+            self.click_resonance(send_click=False, time_out=0.4)
+        self.continues_right_click(0.05)
+        self.absolution_or_confession()
+        self.click_echo(time_out=0)
+        if self.click_liberation(send_click=True):
+            self.state["liberation"] += 1
 
     def zani_linkage(self):
         self.logger.debug('zani linkage')
@@ -306,6 +377,12 @@ class Phoebe(BaseChar):
         return super().switch_next_char(*args, **kwargs)
 
     def get_switch_priority(self, current_char=None, has_intro=False, target_low_con=False):
+        phase = get_zpr_phase(self.task)
+        if phase is not None:
+            expected_char, _ = phase
+            if expected_char == self.__class__.__name__:
+                return SwitchPriority.MUST
+            return SwitchPriority.NO
         if not has_intro and self.last_outro_time > 0 and self.time_elapsed_accounting_for_freeze(
                 self.last_outro_time, intro_motion_freeze=True) < 4.5:
             self.logger.info('performing outro, switch priority no')

--- a/src/char/Qiuyuan.py
+++ b/src/char/Qiuyuan.py
@@ -1,7 +1,7 @@
 import time
 
 from src.char.BaseChar import BaseChar, SwitchPriority
-from src.char.TeamRotations import advance_cqc_phase, get_cqc_phase
+from src.char.TeamRotations import advance_cqc_phase, get_cqc_phase, get_rotation_switch_priority, perform_rotation_phase
 
 
 class Qiuyuan(BaseChar):
@@ -31,18 +31,7 @@ class Qiuyuan(BaseChar):
         self.switch_next_char()
 
     def cartethyia_qiuyuan_chisa_rotation(self):
-        phase = get_cqc_phase(self.task)
-        if phase is None:
-            return False
-        expected_char, action = phase
-        if expected_char != self.__class__.__name__:
-            self.switch_next_char()
-            return True
-        self.wait_down()
-        getattr(self, action)()
-        advance_cqc_phase(self.task)
-        self.switch_next_char()
-        return True
+        return perform_rotation_phase(self, get_cqc_phase, advance_cqc_phase, wait_down=True)
 
     def cqc_qiuyuan_aae_jump_a(self):
         self.continues_normal_attack(0.35)
@@ -63,12 +52,9 @@ class Qiuyuan(BaseChar):
         self.click_echo(time_out=0)
 
     def get_switch_priority(self, current_char=None, has_intro=False, target_low_con=False):
-        phase = get_cqc_phase(self.task)
-        if phase is not None:
-            expected_char, _ = phase
-            if expected_char == self.__class__.__name__:
-                return SwitchPriority.MUST
-            return SwitchPriority.NO
+        priority = get_rotation_switch_priority(self, get_cqc_phase)
+        if priority is not None:
+            return priority
         return super().get_switch_priority(current_char, has_intro, target_low_con)
         
     def shorekeeper_auto_dodge(self):

--- a/src/char/Qiuyuan.py
+++ b/src/char/Qiuyuan.py
@@ -1,10 +1,13 @@
 import time
 
-from src.char.BaseChar import BaseChar
+from src.char.BaseChar import BaseChar, SwitchPriority
+from src.char.TeamRotations import advance_cqc_phase, get_cqc_phase
 
 
 class Qiuyuan(BaseChar):
     def do_perform(self):
+        if self.cartethyia_qiuyuan_chisa_rotation():
+            return
         if self.has_intro:
             self.continues_normal_attack(1.17)
         if self.flying():
@@ -26,6 +29,47 @@ class Qiuyuan(BaseChar):
             self.task.next_frame()
         self.click_resonance()
         self.switch_next_char()
+
+    def cartethyia_qiuyuan_chisa_rotation(self):
+        phase = get_cqc_phase(self.task)
+        if phase is None:
+            return False
+        expected_char, action = phase
+        if expected_char != self.__class__.__name__:
+            self.switch_next_char()
+            return True
+        self.wait_down()
+        getattr(self, action)()
+        advance_cqc_phase(self.task)
+        self.switch_next_char()
+        return True
+
+    def cqc_qiuyuan_aae_jump_a(self):
+        self.continues_normal_attack(0.35)
+        self.click_resonance(time_out=0.4)
+        self.task.jump(after_sleep=0.05)
+        self.continues_normal_attack(0.25)
+
+    def cqc_qiuyuan_aae_jump_z(self):
+        self.continues_normal_attack(0.35)
+        self.click_resonance(time_out=0.4)
+        self.task.jump(after_sleep=0.05)
+        if self.is_mouse_forte_full():
+            self.heavy_click_forte(check_fun=self.is_mouse_forte_full)
+        else:
+            self.heavy_attack(0.35)
+
+    def cqc_qiuyuan_r(self):
+        self.click_echo(time_out=0)
+
+    def get_switch_priority(self, current_char=None, has_intro=False, target_low_con=False):
+        phase = get_cqc_phase(self.task)
+        if phase is not None:
+            expected_char, _ = phase
+            if expected_char == self.__class__.__name__:
+                return SwitchPriority.MUST
+            return SwitchPriority.NO
+        return super().get_switch_priority(current_char, has_intro, target_low_con)
         
     def shorekeeper_auto_dodge(self):
         from src.char.ShoreKeeper import ShoreKeeper

--- a/src/char/TeamRotations.py
+++ b/src/char/TeamRotations.py
@@ -1,0 +1,160 @@
+ZPR_ROTATION_ATTR = "_zani_phoebe_rover_rotation"
+
+ZPR_PHASES = [
+    ("Phoebe", "phoebe_long_e_r_e_q"),
+    ("Zani", "zani_e_a"),
+    ("HavocRover", "rover_r"),
+    ("Zani", "zani_a"),
+    ("Phoebe", "phoebe_aaa_dodge_aaa_dodge_aaa_z"),
+    ("Zani", "zani_e"),
+    ("Phoebe", "phoebe_aaa"),
+    ("Zani", "zani_q_r_aaa"),
+    ("HavocRover", "rover_a_z_a_e_q"),
+    ("Zani", "zani_aaa"),
+    ("Phoebe", "phoebe_z"),
+    ("HavocRover", "rover_a_z_a"),
+    ("Zani", "zani_aaa"),
+    ("HavocRover", "rover_e"),
+    ("Phoebe", "phoebe_intro"),
+    ("HavocRover", "rover_r"),
+    ("Zani", "zani_aa"),
+    ("Phoebe", "phoebe_long_e_r_e_q"),
+    ("Zani", "zani_a"),
+    ("HavocRover", "rover_a_z_a"),
+    ("Zani", "zani_r_e_a"),
+    ("HavocRover", "rover_e"),
+    ("Phoebe", "phoebe_aaa_dodge_z_dodge_aaa_f"),
+    ("Zani", "zani_e_q_r_aaa"),
+    ("HavocRover", "rover_e_q"),
+    ("Phoebe", "phoebe_z"),
+    ("HavocRover", "rover_a"),
+    ("Zani", "zani_aaa"),
+    ("HavocRover", "rover_a_z_a_r"),
+    ("Phoebe", "phoebe_intro"),
+    ("Zani", "zani_aaa"),
+    ("HavocRover", "rover_e"),
+    ("Phoebe", "phoebe_e_dodge_long_e_r_q"),
+    ("Zani", "zani_aaa"),
+    ("HavocRover", "rover_a_z_a"),
+    ("Zani", "zani_r_e_a"),
+]
+
+ZPR_LOOP_START = 21
+
+CQC_ROTATION_ATTR = "_cartethyia_qiuyuan_chisa_rotation"
+
+CQC_PHASES = [
+    ("Chisa", "cqc_chisa_e"),
+    ("Cartethyia", "cqc_cart_e_r_e_e"),
+    ("Chisa", "cqc_chisa_a"),
+    ("Qiuyuan", "cqc_qiuyuan_aae_jump_a"),
+    ("Chisa", "cqc_chisa_a3"),
+    ("Cartethyia", "cqc_cart_a3_a4"),
+    ("Chisa", "cqc_chisa_a4"),
+    ("Qiuyuan", "cqc_qiuyuan_aae_jump_z"),
+    ("Cartethyia", "cqc_cart_a5_r1"),
+    ("Chisa", "cqc_chisa_r_e"),
+    ("Cartethyia", "cqc_cart_a3"),
+    ("Qiuyuan", "cqc_qiuyuan_r"),
+    ("Chisa", "cqc_chisa_z2_dodge_a3"),
+    ("Cartethyia", "cqc_cart_a4_z_q"),
+    ("Chisa", "cqc_chisa_a4"),
+    ("Cartethyia", "cqc_cart_drop_a_z_e3_a_e_e_r"),
+]
+
+CQC_LOOP_START = 0
+
+
+def _find_char(task, char_cls):
+    if hasattr(task, "has_char"):
+        return task.has_char(char_cls)
+    return next((char for char in getattr(task, "chars", []) if isinstance(char, char_cls)), None)
+
+
+def is_zani_phoebe_rover_team(task):
+    from src.char.BaseChar import Elements
+    from src.char.HavocRover import HavocRover
+    from src.char.Phoebe import Phoebe
+    from src.char.Zani import Zani
+
+    rover = _find_char(task, HavocRover)
+    return bool(
+        _find_char(task, Zani)
+        and _find_char(task, Phoebe)
+        and rover
+        and rover.ring_index in (-1, Elements.SPECTRO)
+    )
+
+
+def ensure_zani_phoebe_rover_rotation(task):
+    if not is_zani_phoebe_rover_team(task):
+        return None
+    rotation = getattr(task, ZPR_ROTATION_ATTR, None)
+    if rotation is None:
+        rotation = {"phase": 0}
+        setattr(task, ZPR_ROTATION_ATTR, rotation)
+    return rotation
+
+
+def get_zpr_phase(task):
+    rotation = ensure_zani_phoebe_rover_rotation(task)
+    if rotation is None:
+        return None
+    phase = rotation.get("phase", 0)
+    if phase < 0 or phase >= len(ZPR_PHASES):
+        phase = ZPR_LOOP_START
+        rotation["phase"] = phase
+    return ZPR_PHASES[phase]
+
+
+def advance_zpr_phase(task):
+    rotation = ensure_zani_phoebe_rover_rotation(task)
+    if rotation is None:
+        return
+    phase = rotation.get("phase", 0) + 1
+    if phase >= len(ZPR_PHASES):
+        phase = ZPR_LOOP_START
+    rotation["phase"] = phase
+
+
+def is_cartethyia_qiuyuan_chisa_team(task):
+    from src.char.Cartethyia import Cartethyia
+    from src.char.Chisa import Chisa
+    from src.char.Qiuyuan import Qiuyuan
+
+    return bool(
+        _find_char(task, Cartethyia)
+        and _find_char(task, Qiuyuan)
+        and _find_char(task, Chisa)
+    )
+
+
+def ensure_cartethyia_qiuyuan_chisa_rotation(task):
+    if not is_cartethyia_qiuyuan_chisa_team(task):
+        return None
+    rotation = getattr(task, CQC_ROTATION_ATTR, None)
+    if rotation is None:
+        rotation = {"phase": 0}
+        setattr(task, CQC_ROTATION_ATTR, rotation)
+    return rotation
+
+
+def get_cqc_phase(task):
+    rotation = ensure_cartethyia_qiuyuan_chisa_rotation(task)
+    if rotation is None:
+        return None
+    phase = rotation.get("phase", 0)
+    if phase < 0 or phase >= len(CQC_PHASES):
+        phase = CQC_LOOP_START
+        rotation["phase"] = phase
+    return CQC_PHASES[phase]
+
+
+def advance_cqc_phase(task):
+    rotation = ensure_cartethyia_qiuyuan_chisa_rotation(task)
+    if rotation is None:
+        return
+    phase = rotation.get("phase", 0) + 1
+    if phase >= len(CQC_PHASES):
+        phase = CQC_LOOP_START
+    rotation["phase"] = phase

--- a/src/char/TeamRotations.py
+++ b/src/char/TeamRotations.py
@@ -71,6 +71,37 @@ def _find_char(task, char_cls):
     return next((char for char in getattr(task, "chars", []) if isinstance(char, char_cls)), None)
 
 
+def is_rotation_target(char, expected_char):
+    return any(cls.__name__ == expected_char for cls in char.__class__.mro())
+
+
+def perform_rotation_phase(char, phase_getter, phase_advancer, wait_down=False, wait_down_if_flying=False):
+    phase = phase_getter(char.task)
+    if phase is None:
+        return False
+    expected_char, action = phase
+    if not is_rotation_target(char, expected_char):
+        char.switch_next_char()
+        return True
+    if wait_down or (wait_down_if_flying and char.flying()):
+        char.wait_down()
+    getattr(char, action)()
+    phase_advancer(char.task)
+    char.switch_next_char()
+    return True
+
+
+def get_rotation_switch_priority(char, phase_getter):
+    phase = phase_getter(char.task)
+    if phase is None:
+        return None
+    expected_char, _ = phase
+    from src.char.BaseChar import SwitchPriority
+    if is_rotation_target(char, expected_char):
+        return SwitchPriority.MUST
+    return SwitchPriority.NO
+
+
 def is_zani_phoebe_rover_team(task):
     from src.char.BaseChar import Elements
     from src.char.HavocRover import HavocRover

--- a/src/char/Zani.py
+++ b/src/char/Zani.py
@@ -6,6 +6,7 @@ import numpy as np
 import math
 
 from src.char.BaseChar import BaseChar, SwitchPriority, forte_white_color
+from src.char.TeamRotations import advance_zpr_phase, get_zpr_phase
 from ok import color_range_to_bound
 
 class State(Enum):
@@ -43,6 +44,8 @@ class Zani(BaseChar):
     def do_perform(self):
         if self.blazes_threshold == -1:
             self.decide_teammate()
+        if self.zani_phoebe_rover_rotation():
+            return
         if self.has_intro:
             self.logger.info('has intro')
             self.continues_normal_attack(1.3)
@@ -138,6 +141,66 @@ class Zani(BaseChar):
         if self.is_forte_full():
             self.crisis_response_protocol_combo()
         self.switch_next_char()
+
+    def zani_phoebe_rover_rotation(self):
+        phase = get_zpr_phase(self.task)
+        if phase is None:
+            return False
+        expected_char, action = phase
+        if expected_char != self.__class__.__name__:
+            self.switch_next_char()
+            return True
+        getattr(self, action)()
+        advance_zpr_phase(self.task)
+        self.switch_next_char()
+        return True
+
+    def zani_e_a(self):
+        self.wait_down()
+        self.click_resonance(send_click=False, time_out=0.4)
+        self.continues_normal_attack(0.25)
+
+    def zani_a(self):
+        self.wait_down()
+        self.continues_normal_attack(0.25)
+
+    def zani_e(self):
+        self.wait_down()
+        self.click_resonance(send_click=False, time_out=0.4)
+
+    def zani_aa(self):
+        self.wait_down()
+        self.continues_normal_attack(0.4)
+
+    def zani_aaa(self):
+        self.wait_down()
+        if self.in_liberation:
+            self.nightfall_combo()
+        else:
+            self.continues_normal_attack(0.7)
+
+    def zani_q_r_aaa(self):
+        self.wait_down()
+        if self.click_liberation(send_click=True):
+            self.in_liberation = True
+            self.liberation_time = time.time()
+            self.state = 1
+        self.click_echo(time_out=0)
+        if self.in_liberation:
+            self.nightfall_combo(cancel_last_smash=True)
+        else:
+            self.continues_normal_attack(0.7)
+
+    def zani_e_q_r_aaa(self):
+        self.wait_down()
+        self.click_resonance(send_click=False, time_out=0.4)
+        self.zani_q_r_aaa()
+
+    def zani_r_e_a(self):
+        self.wait_down()
+        self.click_echo(time_out=0)
+        self.click_resonance(send_click=False, time_out=0.4)
+        self.continues_normal_attack(0.25)
 
     def basic_attack_breakthrough_combo(self):
         if self.is_forte_full():
@@ -488,6 +551,12 @@ class Zani(BaseChar):
         self.wait_until(**kwargs)
 
     def get_switch_priority(self, current_char=None, has_intro=False, target_low_con=False):
+        phase = get_zpr_phase(self.task)
+        if phase is not None:
+            expected_char, _ = phase
+            if expected_char == self.__class__.__name__:
+                return SwitchPriority.MUST
+            return SwitchPriority.NO
         if self.in_liberation:
             return SwitchPriority.MUST
         if has_intro and self.crisis_time_left() > 0:

--- a/src/char/Zani.py
+++ b/src/char/Zani.py
@@ -6,7 +6,7 @@ import numpy as np
 import math
 
 from src.char.BaseChar import BaseChar, SwitchPriority, forte_white_color
-from src.char.TeamRotations import advance_zpr_phase, get_zpr_phase
+from src.char.TeamRotations import advance_zpr_phase, get_zpr_phase, get_rotation_switch_priority, perform_rotation_phase
 from ok import color_range_to_bound
 
 class State(Enum):
@@ -143,17 +143,7 @@ class Zani(BaseChar):
         self.switch_next_char()
 
     def zani_phoebe_rover_rotation(self):
-        phase = get_zpr_phase(self.task)
-        if phase is None:
-            return False
-        expected_char, action = phase
-        if expected_char != self.__class__.__name__:
-            self.switch_next_char()
-            return True
-        getattr(self, action)()
-        advance_zpr_phase(self.task)
-        self.switch_next_char()
-        return True
+        return perform_rotation_phase(self, get_zpr_phase, advance_zpr_phase)
 
     def zani_e_a(self):
         self.wait_down()
@@ -551,12 +541,9 @@ class Zani(BaseChar):
         self.wait_until(**kwargs)
 
     def get_switch_priority(self, current_char=None, has_intro=False, target_low_con=False):
-        phase = get_zpr_phase(self.task)
-        if phase is not None:
-            expected_char, _ = phase
-            if expected_char == self.__class__.__name__:
-                return SwitchPriority.MUST
-            return SwitchPriority.NO
+        priority = get_rotation_switch_priority(self, get_zpr_phase)
+        if priority is not None:
+            return priority
         if self.in_liberation:
             return SwitchPriority.MUST
         if has_intro and self.crisis_time_left() > 0:

--- a/tests/TestChar.py
+++ b/tests/TestChar.py
@@ -3,9 +3,10 @@ import unittest
 from config import config
 from ok.test.TaskTestCase import TaskTestCase
 from src.Labels import Labels
-from src.char.BaseChar import BaseChar, CharType, SwitchPriority, get_default_buff_time
+from src.char.BaseChar import BaseChar, CharType, Elements, SwitchPriority, get_default_buff_time
 from src.char.CharFactory import _get_buff_time, _get_char_type, char_dict, char_names
 from src.char.Aemeath import Aemeath
+from src.char.Cartethyia import Cartethyia
 from src.char.Chisa import Chisa
 from src.char.Ciaccona import Ciaccona
 from src.char.Iuno import Iuno
@@ -13,9 +14,13 @@ from src.char.Linnai import Linnai
 from src.char.Lucilla import Lucilla
 from src.char.Lucy import Lucy
 from src.char.Phrolova import Phrolova
+from src.char.HavocRover import HavocRover
+from src.char.Phoebe import Phoebe
+from src.char.Qiuyuan import Qiuyuan
 from src.char.Rebecca import Rebecca
 from src.char.ShoreKeeper import ShoreKeeper
 from src.char.Verina import Verina
+from src.char.Zani import Zani
 from src.task.BaseCombatTask import NotInCombatException
 from src.task.AutoCombatTask import AutoCombatTask
 
@@ -913,6 +918,166 @@ class TestChar(TaskTestCase):
         blocked_healer = BlockedChar(task, 1, char_type=CharType.HEALER)
         combat.chars = [current, blocked_healer, blocked_sub_dps, blocked_main_dps]
         self.assertEqual(combat._choose_switch_target(current, True), current)
+
+    def test_zani_phoebe_rover_rotation_forces_scripted_target(self):
+        from src.char.TeamRotations import (
+            ZPR_LOOP_START,
+            ensure_zani_phoebe_rover_rotation,
+        )
+
+        class Task:
+            def time_elapsed_accounting_for_freeze(self, start, intro_motion_freeze=False):
+                return 10000 if start < 0 else time.time() - start
+
+            def has_char(self, char_cls):
+                return next((char for char in self.chars if isinstance(char, char_cls)), None)
+
+        task = Task()
+        zani = Zani(task, 0)
+        phoebe = Phoebe(task, 1)
+        rover = HavocRover(task, 2, ring_index=Elements.SPECTRO)
+        task.chars = [zani, phoebe, rover]
+        rotation = ensure_zani_phoebe_rover_rotation(task)
+        rotation["phase"] = ZPR_LOOP_START
+
+        self.assertEqual(rover.get_switch_priority(current_char=phoebe), SwitchPriority.MUST)
+        self.assertEqual(zani.get_switch_priority(current_char=phoebe), SwitchPriority.NO)
+        self.assertEqual(phoebe.get_switch_priority(current_char=zani), SwitchPriority.NO)
+
+    def test_zani_phoebe_rover_rotation_rover_loop_starts_with_spectro_e(self):
+        from src.char.TeamRotations import (
+            ZPR_LOOP_START,
+            ensure_zani_phoebe_rover_rotation,
+        )
+
+        class Task:
+            has_lavitator = False
+            use_liberation = True
+
+            def time_elapsed_accounting_for_freeze(self, start, intro_motion_freeze=False):
+                return 10000 if start < 0 else time.time() - start
+
+            def has_char(self, char_cls):
+                return next((char for char in self.chars if isinstance(char, char_cls)), None)
+
+        class TrackingRover(HavocRover):
+            def __init__(self, task, index):
+                super().__init__(task, index, ring_index=Elements.SPECTRO)
+                self.actions = []
+
+            def wait_down(self, click=True):
+                self.actions.append(("wait_down", click))
+
+            def click_resonance(self, **kwargs):
+                self.actions.append(("resonance", kwargs))
+                return True, 0, False
+
+            def click_liberation(self, **kwargs):
+                self.actions.append(("liberation", kwargs))
+                return True
+
+            def click_echo(self, **kwargs):
+                self.actions.append(("echo", kwargs))
+                return True
+
+            def spectro_routine_aftertune_combo(self):
+                self.actions.append(("aZa", {}))
+
+            def switch_next_char(self, *args, **kwargs):
+                self.actions.append(("switch", {}))
+
+        task = Task()
+        zani = Zani(task, 0)
+        phoebe = Phoebe(task, 1)
+        rover = TrackingRover(task, 2)
+        task.chars = [zani, phoebe, rover]
+        rotation = ensure_zani_phoebe_rover_rotation(task)
+        rotation["phase"] = ZPR_LOOP_START
+
+        rover.do_perform()
+
+        self.assertEqual(rover.actions, [
+            ("wait_down", True),
+            ("resonance", {"send_click": False, "time_out": 0.4}),
+            ("switch", {}),
+        ])
+        self.assertNotEqual(rotation["phase"], ZPR_LOOP_START)
+
+    def test_cartethyia_qiuyuan_chisa_rotation_forces_scripted_target(self):
+        from src.char.TeamRotations import ensure_cartethyia_qiuyuan_chisa_rotation
+
+        class Task:
+            char_config = {}
+
+            def time_elapsed_accounting_for_freeze(self, start, intro_motion_freeze=False):
+                return 10000 if start < 0 else time.time() - start
+
+            def has_char(self, char_cls):
+                return next((char for char in self.chars if isinstance(char, char_cls)), None)
+
+        class TestCartethyia(Cartethyia):
+            def __init__(self, task, index):
+                BaseChar.__init__(self, task, index, ring_index=Elements.WIND)
+                self.is_cartethyia = True
+
+        task = Task()
+        cartethyia = TestCartethyia(task, 0)
+        qiuyuan = Qiuyuan(task, 1)
+        chisa = Chisa(task, 2)
+        task.chars = [cartethyia, qiuyuan, chisa]
+        rotation = ensure_cartethyia_qiuyuan_chisa_rotation(task)
+
+        self.assertEqual(rotation["phase"], 0)
+        self.assertEqual(chisa.get_switch_priority(current_char=cartethyia), SwitchPriority.MUST)
+        self.assertEqual(cartethyia.get_switch_priority(current_char=chisa), SwitchPriority.NO)
+        self.assertEqual(qiuyuan.get_switch_priority(current_char=chisa), SwitchPriority.NO)
+
+    def test_cartethyia_qiuyuan_chisa_rotation_chisa_starts_with_e(self):
+        from src.char.TeamRotations import ensure_cartethyia_qiuyuan_chisa_rotation
+
+        class Task:
+            char_config = {}
+
+            def time_elapsed_accounting_for_freeze(self, start, intro_motion_freeze=False):
+                return 10000 if start < 0 else time.time() - start
+
+            def has_char(self, char_cls):
+                return next((char for char in self.chars if isinstance(char, char_cls)), None)
+
+        class TestCartethyia(Cartethyia):
+            def __init__(self, task, index):
+                BaseChar.__init__(self, task, index, ring_index=Elements.WIND)
+                self.is_cartethyia = True
+
+        class TrackingChisa(Chisa):
+            def __init__(self, task, index):
+                super().__init__(task, index)
+                self.actions = []
+
+            def flying(self):
+                return False
+
+            def click_resonance(self, **kwargs):
+                self.actions.append(("resonance", kwargs))
+                return True, 0, False
+
+            def switch_next_char(self, *args, **kwargs):
+                self.actions.append(("switch", {}))
+
+        task = Task()
+        cartethyia = TestCartethyia(task, 0)
+        qiuyuan = Qiuyuan(task, 1)
+        chisa = TrackingChisa(task, 2)
+        task.chars = [cartethyia, qiuyuan, chisa]
+        rotation = ensure_cartethyia_qiuyuan_chisa_rotation(task)
+
+        chisa.do_perform()
+
+        self.assertEqual(chisa.actions, [
+            ("resonance", {"time_out": 0.5}),
+            ("switch", {}),
+        ])
+        self.assertEqual(rotation["phase"], 1)
 
     def test_priority_hooks_for_ciaccona_and_phrolova(self):
         class Task:

--- a/tests/TestChar.py
+++ b/tests/TestChar.py
@@ -954,6 +954,9 @@ class TestChar(TaskTestCase):
             has_lavitator = False
             use_liberation = True
 
+            def sleep(self, sec):
+                pass
+
             def time_elapsed_accounting_for_freeze(self, start, intro_motion_freeze=False):
                 return 10000 if start < 0 else time.time() - start
 
@@ -1070,6 +1073,7 @@ class TestChar(TaskTestCase):
         chisa = TrackingChisa(task, 2)
         task.chars = [cartethyia, qiuyuan, chisa]
         rotation = ensure_cartethyia_qiuyuan_chisa_rotation(task)
+        rotation["phase"] = 0
 
         chisa.do_perform()
 

--- a/tests/TestChar.py
+++ b/tests/TestChar.py
@@ -41,6 +41,33 @@ class ForcedChar(BaseChar):
         return SwitchPriority.MUST
 
 
+class RotationTask:
+    char_config = {}
+    has_lavitator = False
+    use_liberation = True
+
+    def __init__(self, chars=None):
+        self.chars = chars or []
+        self.sleep_calls = []
+
+    def sleep(self, sec):
+        self.sleep_calls.append(sec)
+
+    def time_elapsed_accounting_for_freeze(self, start, intro_motion_freeze=False):
+        if intro_motion_freeze and start < 0:
+            return 10000
+        return 10000 if start < 0 else time.time() - start
+
+    def has_char(self, char_cls):
+        return next((char for char in self.chars if isinstance(char, char_cls)), None)
+
+
+class RotationCartethyia(Cartethyia):
+    def __init__(self, task, index):
+        BaseChar.__init__(self, task, index, ring_index=Elements.WIND)
+        self.is_cartethyia = True
+
+
 class TestChar(TaskTestCase):
     task_class = AutoCombatTask
     config = config
@@ -925,14 +952,7 @@ class TestChar(TaskTestCase):
             ensure_zani_phoebe_rover_rotation,
         )
 
-        class Task:
-            def time_elapsed_accounting_for_freeze(self, start, intro_motion_freeze=False):
-                return 10000 if start < 0 else time.time() - start
-
-            def has_char(self, char_cls):
-                return next((char for char in self.chars if isinstance(char, char_cls)), None)
-
-        task = Task()
+        task = RotationTask()
         zani = Zani(task, 0)
         phoebe = Phoebe(task, 1)
         rover = HavocRover(task, 2, ring_index=Elements.SPECTRO)
@@ -949,19 +969,6 @@ class TestChar(TaskTestCase):
             ZPR_LOOP_START,
             ensure_zani_phoebe_rover_rotation,
         )
-
-        class Task:
-            has_lavitator = False
-            use_liberation = True
-
-            def sleep(self, sec):
-                pass
-
-            def time_elapsed_accounting_for_freeze(self, start, intro_motion_freeze=False):
-                return 10000 if start < 0 else time.time() - start
-
-            def has_char(self, char_cls):
-                return next((char for char in self.chars if isinstance(char, char_cls)), None)
 
         class TrackingRover(HavocRover):
             def __init__(self, task, index):
@@ -989,7 +996,7 @@ class TestChar(TaskTestCase):
             def switch_next_char(self, *args, **kwargs):
                 self.actions.append(("switch", {}))
 
-        task = Task()
+        task = RotationTask()
         zani = Zani(task, 0)
         phoebe = Phoebe(task, 1)
         rover = TrackingRover(task, 2)
@@ -1009,22 +1016,8 @@ class TestChar(TaskTestCase):
     def test_cartethyia_qiuyuan_chisa_rotation_forces_scripted_target(self):
         from src.char.TeamRotations import ensure_cartethyia_qiuyuan_chisa_rotation
 
-        class Task:
-            char_config = {}
-
-            def time_elapsed_accounting_for_freeze(self, start, intro_motion_freeze=False):
-                return 10000 if start < 0 else time.time() - start
-
-            def has_char(self, char_cls):
-                return next((char for char in self.chars if isinstance(char, char_cls)), None)
-
-        class TestCartethyia(Cartethyia):
-            def __init__(self, task, index):
-                BaseChar.__init__(self, task, index, ring_index=Elements.WIND)
-                self.is_cartethyia = True
-
-        task = Task()
-        cartethyia = TestCartethyia(task, 0)
+        task = RotationTask()
+        cartethyia = RotationCartethyia(task, 0)
         qiuyuan = Qiuyuan(task, 1)
         chisa = Chisa(task, 2)
         task.chars = [cartethyia, qiuyuan, chisa]
@@ -1037,20 +1030,6 @@ class TestChar(TaskTestCase):
 
     def test_cartethyia_qiuyuan_chisa_rotation_chisa_starts_with_e(self):
         from src.char.TeamRotations import ensure_cartethyia_qiuyuan_chisa_rotation
-
-        class Task:
-            char_config = {}
-
-            def time_elapsed_accounting_for_freeze(self, start, intro_motion_freeze=False):
-                return 10000 if start < 0 else time.time() - start
-
-            def has_char(self, char_cls):
-                return next((char for char in self.chars if isinstance(char, char_cls)), None)
-
-        class TestCartethyia(Cartethyia):
-            def __init__(self, task, index):
-                BaseChar.__init__(self, task, index, ring_index=Elements.WIND)
-                self.is_cartethyia = True
 
         class TrackingChisa(Chisa):
             def __init__(self, task, index):
@@ -1067,8 +1046,8 @@ class TestChar(TaskTestCase):
             def switch_next_char(self, *args, **kwargs):
                 self.actions.append(("switch", {}))
 
-        task = Task()
-        cartethyia = TestCartethyia(task, 0)
+        task = RotationTask()
+        cartethyia = RotationCartethyia(task, 0)
         qiuyuan = Qiuyuan(task, 1)
         chisa = TrackingChisa(task, 2)
         task.chars = [cartethyia, qiuyuan, chisa]


### PR DESCRIPTION
## 修复问题

- https://github.com/ok-oldking/ok-wuthering-waves/issues/1248
- https://github.com/ok-oldking/ok-wuthering-waves/issues/1260

## 修改内容

- 增加固定轴队伍轮换脚本。
- 支持赞妮 / 菲比 / 湮灭漂泊者队伍的固定轴逻辑。
- 支持卡提希娅 / 秋水 / 千咲队伍的固定轴逻辑。
- 轮换逻辑集中在 `src/char/TeamRotations.py`，各角色只在命中特定配队时接入。
- 抽出通用兜底修复：
  - 卡提希娅默认逻辑在补剑后会刷新状态并尝试下落攻击，避免补完 3 剑后直接切人或过早进入后续动作。
  - 菲比默认逻辑在成功进入祈愿状态后，会先补一段重击续接准备，再执行原有 `starflash_combo`，降低只普攻不续重击的概率。

## 兼容说明

固定轴只在指定配队命中时触发，防止部分修改影响溢出到其他配队，干扰其他队伍合轴。

通用兜底只调整卡提希娅和菲比各自的默认动作顺序，不引入跨角色配队状态。

## 数值增长

- 卡夏守：8375（手动） -> 9284
- 赞菲光：5400（旧自动） -> 6300

## 测试

- `python -m py_compile src\\char\\Cartethyia.py src\\char\\Chisa.py src\\char\\HavocRover.py src\\char\\Phoebe.py src\\char\\Qiuyuan.py src\\char\\TeamRotations.py src\\char\\Zani.py tests\\TestChar.py`
- `python -m unittest tests.TestChar` 当前本机缺少 `qfluentwidgets`，无法完整运行。

## 截图

截图对比可在 PR 评论中补充上传。