### PR TITLE
At garden entrance, select Blessing1 to boost stability

### DIFF
--- a/src/task/GardenTask.py
+++ b/src/task/GardenTask.py
@@ -126,7 +126,6 @@ class GardenTask(WWOneTimeTask, BaseWWTask):
         self.click(700/1920, 666/1080, after_sleep=2)
         # confirm
         self.click(1600/1920, 900/1080, after_sleep=2)
-        
 
 if __name__ == "__main__":
     run_task(config, task=GardenTask, debug=True)

--- a/src/task/GardenTask.py
+++ b/src/task/GardenTask.py
@@ -62,7 +62,7 @@ class GardenTask(WWOneTimeTask, BaseWWTask):
                     continue
                 elif target.name == 'garden_start_game':
                     # At Garden Entrance, choose blessing1
-                    self._choose_blessing1()
+                    self._choose_first_blessing()
                 self.log_info(f"click {target.name} {target.confidence:.3f}")
                 self.click(target, after_sleep=1)
             else:
@@ -118,8 +118,8 @@ class GardenTask(WWOneTimeTask, BaseWWTask):
                 return max(priority_matches, key=lambda box: box.confidence)
         return max(matches, key=lambda box: box.confidence, default=None)
 
-    def _choose_blessing1(self):
-        """At Garden Entrance, choose blessing1"""
+    def _choose_first_blessing(self):
+        """At Garden Entrance, choose first blessing"""
         # click blessing botton
         self.click(965/1920, 860/1080, after_sleep=2)
         # choose blessing1(Add-on)

--- a/src/task/GardenTask.py
+++ b/src/task/GardenTask.py
@@ -60,6 +60,9 @@ class GardenTask(WWOneTimeTask, BaseWWTask):
                     self.click(not_interested[-1], after_sleep=1)
                     self.click(self.get_box_by_name('garden_not_interested_confirm'), after_sleep=1)
                     continue
+                elif target.name == 'garden_start_game':
+                    # At Garden Entrance, choose blessing1
+                    self._choose_blessing1()
                 self.log_info(f"click {target.name} {target.confidence:.3f}")
                 self.click(target, after_sleep=1)
             else:
@@ -115,6 +118,15 @@ class GardenTask(WWOneTimeTask, BaseWWTask):
                 return max(priority_matches, key=lambda box: box.confidence)
         return max(matches, key=lambda box: box.confidence, default=None)
 
+    def _choose_blessing1(self):
+        """At Garden Entrance, choose blessing1"""
+        # click blessing botton
+        self.click(965/1920, 860/1080, after_sleep=2)
+        # choose blessing1(Add-on)
+        self.click(700/1920, 666/1080, after_sleep=2)
+        # confirm
+        self.click(1600/1920, 900/1080, after_sleep=2)
+        
 
 if __name__ == "__main__":
     run_task(config, task=GardenTask, debug=True)


### PR DESCRIPTION
# PR 说明 / PR Description

## 修改内容 / Changes

- 乐园进入时，选择祝福1，避免因为未选祝福而卡住，增强稳定性
<img width="3061" height="1691" alt="7934E9F7BBA506127F786DDD06D9D76B" src="https://github.com/user-attachments/assets/bc3dcf54-1415-4983-ab8f-09e3d38dd219" />

## 修改类型 / Type of Change

请选择适用项：

Please check all that apply:

- [ ] Bug 修复 / Bug fix
- [ ] 文档或翻译 / Documentation or translation
- [x] 小型优化或兼容性修复 / Small improvement or compatibility fix
- [ ] 新功能 / New feature
- [ ] 大幅修改现有功能 / Major modification of existing behavior
- [ ] 重构或架构调整 / Refactor or architecture change

## 新功能或大改确认 / New Feature or Major Change Confirmation

如果本 PR 包含新功能，或会大幅修改当前功能、任务行为、角色逻辑、识别逻辑、配置结构或用户体验，请先联系作者或在社区中讨论后再提交。

If this PR adds a new feature, or significantly changes existing features, task behavior, character logic, recognition logic, configuration structure, or user experience, please contact the author or discuss it with the community before submitting.

- [x] 不适用，本 PR 不是新功能或大改 / Not applicable; this PR is not a new feature or major change
- [ ] 已联系作者或已在社区讨论 / I have contacted the author or discussed this in the community

## 测试 / Testing

- 运行【自动周常乐园】最开始会选择祝福1

## 截图或录屏 / Screenshots or Recordings
测试图片：
<img width="1920" height="1080" alt="Windows Graphics Capture_1920x1080_1782728292036 0398_original" src="https://github.com/user-attachments/assets/8f00127b-446c-4a3c-ae7d-53f81227f407" />
<img width="1920" height="1080" alt="Windows Graphics Capture_1920x1080_1782728315385 8613_original" src="https://github.com/user-attachments/assets/3a0bfc40-5b1c-48d3-a547-0947c0f585da" />


## 检查清单 / Checklist

- [x] 我已阅读 [CONTRIBUTING.md](https://github.com/ok-oldking/ok-wuthering-waves/blob/master/CONTRIBUTING.md) / I have read [CONTRIBUTING.md](https://github.com/ok-oldking/ok-wuthering-waves/blob/master/CONTRIBUTING.md)
- [x] 我已阅读 README 中的免责声明 / I have read the disclaimer in the README
- [x] 我已尽量保持 PR 范围清晰，没有混入无关修改 / I have kept this PR focused and avoided unrelated changes
- [x] 我已说明测试结果或无法测试的原因 / I have described the test results or why testing was not possible
- [x] 我没有提交日志、缓存、临时文件或个人配置 / I have not committed logs, caches, temporary files, or personal settings

## 社区联系方式 / Community Contact

- 开发者群 / Developer QQ group: `926858895`
- Discord: [https://discord.gg/vVyCatEBgA](https://discord.gg/vVyCatEBgA)
