### PR TITLE
优化乐园挑战失败时返回主页的流程

### DIFF
--- a/src/task/GardenTask.py
+++ b/src/task/GardenTask.py
@@ -32,12 +32,12 @@ class GardenTask(WWOneTimeTask, BaseWWTask):
 
     def run(self):
         WWOneTimeTask.run(self)
-        # self.ensure_main()
-        # self.open_garden_weekly_page()
-        # if self.is_weekly_garden_completed():
-        #     self.log_info('乐园任务完成, 已达到上限', notify=True)
-        #     return
-        # self.click(0.246, 0.486, after_sleep=1)
+        self.ensure_main()
+        self.open_garden_weekly_page()
+        if self.is_weekly_garden_completed():
+            self.log_info('乐园任务完成, 已达到上限', notify=True)
+            return
+        self.click(0.246, 0.486, after_sleep=1)
         while True:
             self.sleep(0.1)
             target = self.find_best_garden_feature()

--- a/src/task/GardenTask.py
+++ b/src/task/GardenTask.py
@@ -32,12 +32,12 @@ class GardenTask(WWOneTimeTask, BaseWWTask):
 
     def run(self):
         WWOneTimeTask.run(self)
-        self.ensure_main()
-        self.open_garden_weekly_page()
-        if self.is_weekly_garden_completed():
-            self.log_info('乐园任务完成, 已达到上限', notify=True)
-            return
-        self.click(0.246, 0.486, after_sleep=1)
+        # self.ensure_main()
+        # self.open_garden_weekly_page()
+        # if self.is_weekly_garden_completed():
+        #     self.log_info('乐园任务完成, 已达到上限', notify=True)
+        #     return
+        # self.click(0.246, 0.486, after_sleep=1)
         while True:
             self.sleep(0.1)
             target = self.find_best_garden_feature()
@@ -69,6 +69,8 @@ class GardenTask(WWOneTimeTask, BaseWWTask):
                 garden_restart = self.find_one('a_garden_restart')
                 garden_back = self.find_one('a_garden_back')
                 if garden_restart and garden_back:
+                    # 避免因点击太快，导致[挑战失败]页面中点击[返回主页]失败
+                    self.sleep(2)
                     texts = self.ocr(0.373, 0.346, 0.859, 0.615)
                     self.log_info('garden end {}'.format(texts))
                     if self.is_garden_done(texts):


### PR DESCRIPTION
# PR 说明 / PR Description

## 修改内容 / Changes

Fix https://github.com/ok-oldking/ok-wuthering-waves/issues/1424

## 修改类型 / Type of Change

请选择适用项：

Please check all that apply:

- [x] Bug 修复 / Bug fix
- [ ] 文档或翻译 / Documentation or translation
- [ ] 小型优化或兼容性修复 / Small improvement or compatibility fix
- [ ] 新功能 / New feature
- [ ] 大幅修改现有功能 / Major modification of existing behavior
- [ ] 重构或架构调整 / Refactor or architecture change

## 新功能或大改确认 / New Feature or Major Change Confirmation

如果本 PR 包含新功能，或会大幅修改当前功能、任务行为、角色逻辑、识别逻辑、配置结构或用户体验，请先联系作者或在社区中讨论后再提交。

If this PR adds a new feature, or significantly changes existing features, task behavior, character logic, recognition logic, configuration structure, or user experience, please contact the author or discuss it with the community before submitting.

- [x] 不适用，本 PR 不是新功能或大改 / Not applicable; this PR is not a new feature or major change
- [ ] 已联系作者或已在社区讨论 / I have contacted the author or discussed this in the community

## 测试 / Testing

- 在[挑战失败]界面可以成功点击[返回主页]


## 检查清单 / Checklist

- [x] 我已阅读 [CONTRIBUTING.md](https://github.com/ok-oldking/ok-wuthering-waves/blob/master/CONTRIBUTING.md) / I have read [CONTRIBUTING.md](https://github.com/ok-oldking/ok-wuthering-waves/blob/master/CONTRIBUTING.md)
- [x] 我已阅读 README 中的免责声明 / I have read the disclaimer in the README
- [x] 我已尽量保持 PR 范围清晰，没有混入无关修改 / I have kept this PR focused and avoided unrelated changes
- [x] 我已说明测试结果或无法测试的原因 / I have described the test results or why testing was not possible
- [x] 我没有提交日志、缓存、临时文件或个人配置 / I have not committed logs, caches, temporary files, or personal settings

## 社区联系方式 / Community Contact

- 开发者群 / Developer QQ group: `926858895`
- Discord: [https://discord.gg/vVyCatEBgA](https://discord.gg/vVyCatEBgA)
