### PR TITLE
fix: wait before clicking login button during auto login

### DIFF
--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -17,6 +17,7 @@ logger = Logger.get_logger(__name__)
 number_re = re.compile(r'(\d+)')
 stamina_re = re.compile(r'(\d+)/(\d+)')
 LOGIN_TEXTS = ["登录", re.compile('Log', re.IGNORECASE), '登入']
+LOGIN_CLICK_SETTLE_TIME = 4  # seconds; keep below AutoLoginTask trigger_interval (5) so triggers don't overlap
 f_white_color = {
     'r': (235, 255),  # Red range
     'g': (235, 255),  # Green range
@@ -716,8 +717,16 @@ class BaseWWTask(BaseTask):
             if login := self.find_boxes(texts, boundary=self.box_of_screen(0.3, 0.3, 0.7, 0.7),
                                         match=LOGIN_TEXTS):
                 if not self.find_boxes(texts, boundary=self.box_of_screen(0.3, 0.3, 0.7, 0.7), match="+86"):
-                    self.click(login, after_sleep=1)
-                    self.log_info('点击登录按钮!')
+                    # the game may be auto logging in with saved credentials, wait and
+                    # confirm the login button is still there before clicking (#1356)
+                    self.sleep(LOGIN_CLICK_SETTLE_TIME)
+                    texts = self.ocr(log=self.debug)
+                    login = self.find_boxes(texts, boundary=self.box_of_screen(0.3, 0.3, 0.7, 0.7),
+                                            match=LOGIN_TEXTS)
+                    if login and not self.find_boxes(texts, boundary=self.box_of_screen(0.3, 0.3, 0.7, 0.7),
+                                                     match="+86"):
+                        self.click(login, after_sleep=1)
+                        self.log_info('点击登录按钮!')
                 return False
             if agree := self.find_boxes(texts, boundary=self.box_of_screen(0.3, 0.3, 0.7, 0.7), match="同意"):
                 self.log_debug(f'found agree {agree}')

--- a/tests/TestWaitLogin.py
+++ b/tests/TestWaitLogin.py
@@ -1,0 +1,110 @@
+import unittest
+
+from src.task.BaseWWTask import BaseWWTask, LOGIN_CLICK_SETTLE_TIME, LOGIN_TEXTS
+
+
+class TextBox:
+    def __init__(self, name):
+        self.name = name
+
+
+class FakeLoginTask:
+    """Drives BaseWWTask.wait_login with scripted OCR frames.
+
+    Each entry in frames is the list of TextBox returned by one ocr() call,
+    so a frame sequence like [[login], []] simulates a login button that
+    disappears while the game's own auto login is running (#1356).
+    """
+
+    def __init__(self, frames):
+        self.frames = list(frames)
+        self.logged_in = False
+        self.debug = False
+        self.clicked = []
+        self.slept = []
+
+    def in_team_and_world(self):
+        return False
+
+    def handle_monthly_card(self):
+        return False
+
+    def find_one(self, *args, **kwargs):
+        return None
+
+    def box_of_screen(self, *args):
+        return args
+
+    def ocr(self, log=False):
+        return self.frames.pop(0) if self.frames else []
+
+    def find_boxes(self, texts, boundary=None, match=None):
+        if not texts:
+            return None
+        if match == LOGIN_TEXTS:
+            return [b for b in texts
+                    if 'log' in b.name.lower() or '登录' in b.name or '登入' in b.name] or None
+        if match == "+86":
+            return [b for b in texts if '+86' in b.name] or None
+        return None
+
+    def click(self, target, after_sleep=0):
+        self.clicked.append([b.name for b in target])
+
+    def sleep(self, timeout):
+        self.slept.append(timeout)
+
+    def log_info(self, *args, **kwargs):
+        pass
+
+    def log_debug(self, *args, **kwargs):
+        pass
+
+
+class TestWaitLogin(unittest.TestCase):
+
+    def test_transient_login_button_is_not_clicked(self):
+        # Global server auto login: the login button disappears by itself,
+        # clicking it would pop up the account/password dialog (#1356).
+        task = FakeLoginTask(frames=[[TextBox('Log In')], []])
+
+        result = BaseWWTask.wait_login(task)
+
+        self.assertFalse(result)
+        self.assertEqual(task.clicked, [])
+        self.assertEqual(task.slept, [LOGIN_CLICK_SETTLE_TIME])
+
+    def test_persistent_login_button_is_clicked(self):
+        # No saved credentials: the login button stays, so it must be clicked.
+        task = FakeLoginTask(frames=[[TextBox('Log In')], [TextBox('Log In')]])
+
+        result = BaseWWTask.wait_login(task)
+
+        self.assertFalse(result)
+        self.assertEqual(task.clicked, [['Log In']])
+
+    def test_no_click_and_no_settle_when_phone_login_is_already_shown(self):
+        # +86 phone login present on the first frame: the pre-existing guard
+        # must skip both the click and the settle wait entirely.
+        task = FakeLoginTask(frames=[[TextBox('登录'), TextBox('+86 手机号')]])
+
+        result = BaseWWTask.wait_login(task)
+
+        self.assertFalse(result)
+        self.assertEqual(task.clicked, [])
+        self.assertEqual(task.slept, [])
+
+    def test_no_click_when_phone_login_appears_after_settle(self):
+        # CN phone-number login screen (+86) must never be auto clicked,
+        # even when it only shows up on the confirmation frame.
+        task = FakeLoginTask(frames=[[TextBox('登录')],
+                                     [TextBox('登录'), TextBox('+86 手机号')]])
+
+        result = BaseWWTask.wait_login(task)
+
+        self.assertFalse(result)
+        self.assertEqual(task.clicked, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# PR 说明 / PR Description

## 修改内容 / Changes

修复 #1356：国际服一条龙启动时，账号已自动登录仍弹出登录账号框。

**根因**：`BaseWWTask.wait_login()` 的登录按钮分支（`src/task/BaseWWTask.py:716`）在第一帧 OCR 命中 `LOGIN_TEXTS` 后立即点击，没有任何等待/确认。国际服使用已保存凭据自动登录时，登录按钮会短暂闪现随后自行消失——工具抢先点击导致弹出手动账号密码框，与游戏自身的自动登录赛跑（即 issue 截图中的现象）。`e7be4d18` 将匹配放宽为不区分大小写的子串 `Log` 后更易误触；#1333 的两次修复（`d2881d18`、`6521c0ab`）只加固了 `switch_account` 分支，未处理此文字分支。

**修复**（即 issue 中报告者建议的方向）：检测到登录按钮后先 `sleep(LOGIN_CLICK_SETTLE_TIME=4)` 秒，重新 OCR 确认按钮仍然存在（且无 +86 手机号登录界面）才点击。若自动登录期间按钮自行消失则不点击。改动位于共用函数一处，`DailyTask` / `MultiAccountDailyTask` / `AutoLoginTask` 三条路径同时受益。

- 修改：`src/task/BaseWWTask.py`（登录分支 + 常量，净 +9 行）
- 新增：`tests/TestWaitLogin.py`（4 个用例，沿用 `TestMultiAccountDailyTask.py` 的 FakeTask 模式，无需游戏环境）

Fix #1356: on Global server the tool clicks the transiently-shown login button before the game's own auto-login (with saved credentials) completes, popping up the manual account/password dialog. `wait_login()` now waits 4s and re-verifies the login button is still present (and no +86 phone-login screen) before clicking. Tests included (FakeTask pattern, no game required).

## 修改类型 / Type of Change

- [x] Bug 修复 / Bug fix
- [ ] 文档或翻译 / Documentation or translation
- [ ] 小型优化或兼容性修复 / Small improvement or compatibility fix
- [ ] 新功能 / New feature
- [ ] 大幅修改现有功能 / Major modification of existing behavior
- [ ] 重构或架构调整 / Refactor or architecture change

## 新功能或大改确认 / New Feature or Major Change Confirmation

- [x] 不适用，本 PR 不是新功能或大改 / Not applicable; this PR is not a new feature or major change
- [ ] 已联系作者或已在社区讨论 / I have contacted the author or discussed this in the community

相关讨论链接或联系方式说明：

- Bug 修复，依 CONTRIBUTING.md 直接提交；已在 #1356 留言说明根因分析。

## 测试 / Testing

- 新增 `tests/TestWaitLogin.py` 4 用例：瞬态按钮不点击（修复前失败、修复后通过）、持续存在的按钮正常点击（防回归）、+86 界面首帧/确认帧均不点击、并断言确实执行了等待。
- 本地（Linux，ok-script 以最小 stub 替代）：修复前 2 个用例失败（按预期 RED），修复后 4/4 通过（GREEN）。CI 的 windows 环境会以完整依赖运行全部 tests/*.py。
- **未经国际服实机验证**（开发环境无 Windows/游戏）。已在 #1356 请报告者协助验证；`LOGIN_CLICK_SETTLE_TIME` 为常量，若 4 秒不足可据实测调整。

## 截图或录屏 / Screenshots or Recordings

- 纯时序逻辑修复，无 UI 变更；行为差异仅为登录按钮点击前多等 4 秒确认。

## 检查清单 / Checklist

- [x] 我已阅读 [CONTRIBUTING.md](https://github.com/ok-oldking/ok-wuthering-waves/blob/master/CONTRIBUTING.md) / I have read CONTRIBUTING.md
- [x] 我已阅读 README 中的免责声明 / I have read the disclaimer in the README
- [x] 我已尽量保持 PR 范围清晰，没有混入无关修改 / I have kept this PR focused and avoided unrelated changes
- [x] 我已说明测试结果或无法测试的原因 / I have described the test results or why testing was not possible
- [x] 我没有提交日志、缓存、临时文件或个人配置 / I have not committed logs, caches, temporary files, or personal settings
