### PR TITLE
fix: echo drop status search box may be smaller than sibling template

### DIFF
--- a/src/task/EnhanceEchoTask.py
+++ b/src/task/EnhanceEchoTask.py
@@ -286,8 +286,12 @@ class EnhanceEchoTask(BaseWWTask, FindFeature):
         self.info_incr('失败声骸数量')
         start = time.time()
         success = False
+        drop_status_box = get_bounding_box([
+            self.get_box_by_name('echo_dropped'),
+            self.get_box_by_name('echo_not_dropped'),
+        ]).scale(1.05)
         while time.time() - start < 5:
-            drop_status = self.find_best_match_in_box(self.get_box_by_name('echo_dropped').scale(1.05),
+            drop_status = self.find_best_match_in_box(drop_status_box,
                                                       ['echo_dropped', 'echo_not_dropped'], threshold=0.7)
             if not drop_status:
                 raise Exception('无法找到声骸弃置状态!')
@@ -325,7 +329,7 @@ class EnhanceEchoTask(BaseWWTask, FindFeature):
             if drop_status.name == 'echo_not_locked':
                 self.send_key('c', after_sleep=1)
             else:
-                self.log_info('成功弃置!')
+                self.log_info('成功上锁!')
                 success = True
                 break
         if not success:

--- a/tests/TestEnhanceEchoStatusBox.py
+++ b/tests/TestEnhanceEchoStatusBox.py
@@ -1,0 +1,93 @@
+import unittest
+
+from ok.feature.Box import Box
+from src.task.EnhanceEchoTask import EnhanceEchoTask
+
+
+class FakeEnhanceTask:
+    """Drives the drop/lock status checks with scripted feature boxes.
+
+    find_best_match_in_box records every search box it receives, so a test
+    can assert the box covers both sibling templates: a sibling template
+    larger than the search area crashes cv2.matchTemplate (#1238, #1291).
+    """
+
+    def __init__(self, boxes, match_name):
+        self.boxes = boxes
+        self.match_name = match_name
+        self.searched_boxes = []
+        self.fail_reason = ''
+        self.config = {}
+        self.counters = {}
+
+    def get_box_by_name(self, name):
+        return self.boxes[name]
+
+    def find_best_match_in_box(self, box, names, threshold=0):
+        self.searched_boxes.append(box)
+        return Box(0, 0, 1, 1, name=self.match_name)
+
+    def info_incr(self, name):
+        self.counters[name] = self.counters.get(name, 0) + 1
+
+    def info_get(self, name):
+        return self.counters.get(name, 0)
+
+    def send_key(self, key, after_sleep=0):
+        pass
+
+    def log_info(self, *args, **kwargs):
+        pass
+
+    def screenshot_echo(self, name):
+        pass
+
+    def esc(self):
+        pass
+
+    def wait_ocr(self, *args, **kwargs):
+        return None
+
+
+class TestEnhanceEchoStatusBox(unittest.TestCase):
+    # Sibling templates deliberately differ in size, with the sibling BIGGER
+    # than the anchor box: the geometry that crashed the lock pair in
+    # #1238/#1291.
+
+    def assertCovers(self, search, template_box):
+        self.assertLessEqual(search.x, template_box.x)
+        self.assertLessEqual(search.y, template_box.y)
+        self.assertGreaterEqual(search.x + search.width,
+                                template_box.x + template_box.width)
+        self.assertGreaterEqual(search.y + search.height,
+                                template_box.y + template_box.height)
+
+    def test_drop_search_box_covers_both_drop_templates(self):
+        dropped = Box(534, 152, 28, 26, name='echo_dropped')
+        not_dropped = Box(534, 151, 28, 29, name='echo_not_dropped')
+        task = FakeEnhanceTask({'echo_dropped': dropped,
+                                'echo_not_dropped': not_dropped},
+                               match_name='echo_dropped')
+
+        EnhanceEchoTask.trash_and_esc(task)
+
+        self.assertEqual(len(task.searched_boxes), 1)
+        self.assertCovers(task.searched_boxes[0], dropped)
+        self.assertCovers(task.searched_boxes[0], not_dropped)
+
+    def test_lock_search_box_covers_both_lock_templates(self):
+        locked = Box(631, 152, 23, 26, name='echo_locked')
+        not_locked = Box(631, 151, 24, 29, name='echo_not_locked')
+        task = FakeEnhanceTask({'echo_locked': locked,
+                                'echo_not_locked': not_locked},
+                               match_name='echo_locked')
+
+        EnhanceEchoTask.lock_and_esc(task)
+
+        self.assertEqual(len(task.searched_boxes), 1)
+        self.assertCovers(task.searched_boxes[0], locked)
+        self.assertCovers(task.searched_boxes[0], not_locked)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/TestEnhanceEchoStatusBox.py
+++ b/tests/TestEnhanceEchoStatusBox.py
@@ -7,15 +7,15 @@ from src.task.EnhanceEchoTask import EnhanceEchoTask
 class FakeEnhanceTask:
     """Drives the drop/lock status checks with scripted feature boxes.
 
-    find_best_match_in_box records every search box it receives, so a test
-    can assert the box covers both sibling templates: a sibling template
+    find_best_match_in_box records every call it receives, so a test can
+    assert the search box covers both sibling templates: a sibling template
     larger than the search area crashes cv2.matchTemplate (#1238, #1291).
     """
 
     def __init__(self, boxes, match_name):
         self.boxes = boxes
         self.match_name = match_name
-        self.searched_boxes = []
+        self.search_calls = []
         self.fail_reason = ''
         self.config = {}
         self.counters = {}
@@ -24,7 +24,7 @@ class FakeEnhanceTask:
         return self.boxes[name]
 
     def find_best_match_in_box(self, box, names, threshold=0):
-        self.searched_boxes.append(box)
+        self.search_calls.append((box, names, threshold))
         return Box(0, 0, 1, 1, name=self.match_name)
 
     def info_incr(self, name):
@@ -34,16 +34,16 @@ class FakeEnhanceTask:
         return self.counters.get(name, 0)
 
     def send_key(self, key, after_sleep=0):
-        pass
+        """No-op: key presses do not affect the search-box geometry."""
 
     def log_info(self, *args, **kwargs):
-        pass
+        """No-op: logging is irrelevant to the assertions."""
 
     def screenshot_echo(self, name):
-        pass
+        """No-op: screenshots are irrelevant to the assertions."""
 
     def esc(self):
-        pass
+        """No-op: leaving the screen is irrelevant to the assertions."""
 
     def wait_ocr(self, *args, **kwargs):
         return None
@@ -71,9 +71,11 @@ class TestEnhanceEchoStatusBox(unittest.TestCase):
 
         EnhanceEchoTask.trash_and_esc(task)
 
-        self.assertEqual(len(task.searched_boxes), 1)
-        self.assertCovers(task.searched_boxes[0], dropped)
-        self.assertCovers(task.searched_boxes[0], not_dropped)
+        [(search, names, threshold)] = task.search_calls
+        self.assertEqual(names, ['echo_dropped', 'echo_not_dropped'])
+        self.assertEqual(threshold, 0.7)
+        self.assertCovers(search, dropped)
+        self.assertCovers(search, not_dropped)
 
     def test_lock_search_box_covers_both_lock_templates(self):
         locked = Box(631, 152, 23, 26, name='echo_locked')
@@ -84,9 +86,11 @@ class TestEnhanceEchoStatusBox(unittest.TestCase):
 
         EnhanceEchoTask.lock_and_esc(task)
 
-        self.assertEqual(len(task.searched_boxes), 1)
-        self.assertCovers(task.searched_boxes[0], locked)
-        self.assertCovers(task.searched_boxes[0], not_locked)
+        [(search, names, threshold)] = task.search_calls
+        self.assertEqual(names, ['echo_locked', 'echo_not_locked'])
+        self.assertEqual(threshold, 0.7)
+        self.assertCovers(search, locked)
+        self.assertCovers(search, not_locked)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Problem

#1238 reports the echo enhance task stopping after the first qualifying echo. The attached log shows a crash on the success path:

```
ERROR FeatureSet:feature template echo_not_locked echo_locked size greater than search area (39, 32, 3) > (37, 33, 3)
cv2.error: ... (-215:Assertion failed) _img.size().height <= _templ.size().height ... in function 'cv::matchTemplate'
```

`lock_and_esc` searched for both `echo_locked` and `echo_not_locked` inside only the `echo_locked` box scaled 1.05x, and the sibling template was larger than that box. ff782996 (fix #1291, the same crash) fixed the lock pair with `get_bounding_box` of both feature boxes.

`trash_and_esc` still uses the single-box pattern. It does not crash with the current annotations only because `echo_dropped` (28x26) happens to be larger than `echo_not_dropped` (27x25). If those templates are ever re-captured with the sibling larger, the crash returns on the discard path, which runs far more often than the success path.

## Changes

- `trash_and_esc`: build the search box from `get_bounding_box([echo_dropped, echo_not_dropped]).scale(1.05)`, the same pattern ff782996 applied to the lock pair.
- `lock_and_esc`: the log message after locking said `成功弃置!`; it now says `成功上锁!`.

## Tests

`tests/TestEnhanceEchoStatusBox.py`, following the fake-task pattern of `TestWaitLogin.py`. Both tests give the sibling template a taller box than its anchor, the same shape as the #1238 crash. The drop test fails without this change and passes with it; the lock test covers the ff782996 behavior. Verified with `python -m unittest tests.TestEnhanceEchoStatusBox` (2 tests, both pass; run on Linux with the Windows-only imports stubbed, so please also run on Windows).
