### PR TITLE
修复梦魇巢穴全选不刷残像聚落bug

### DIFF
--- a/src/task/NightmareNestTask.py
+++ b/src/task/NightmareNestTask.py
@@ -163,11 +163,11 @@ class NightmareNestTask(WWOneTimeTask, BaseCombatTask):
     def _init_queue(self):
         quests = self.config.get('Which to Farm') or ['Nightmare Purification', 'Tacet Discord Nest']
         actions = []
+        if 'Tacet Discord Nest' in quests:
+            actions.append(self.go_nest)
         if 'Nightmare Purification' in quests:
             actions.append(self.go_nightmare)
             actions.append(self.go_nightmare_scroll)
-        if 'Tacet Discord Nest' in quests:
-            actions.append(self.go_nest)
         self.queues = actions
 
     def go_nightmare(self):

--- a/tests/TestNightmareNestTask.py
+++ b/tests/TestNightmareNestTask.py
@@ -16,6 +16,13 @@ class FakeBox:
 
 class TestNightmareNestTask(unittest.TestCase):
 
+    def test_nest_is_checked_before_nightmare_changes_book_scroll(self):
+        task = NightmareNestTask.__new__(NightmareNestTask)
+        task.config = {'Which to Farm': ['Nightmare Purification', 'Tacet Discord Nest']}
+        task._init_queue()
+        self.assertEqual(['go_nest', 'go_nightmare', 'go_nightmare_scroll'],
+                         [action.__name__ for action in task.queues])
+
     def test_capture_success_clears_combat_before_post_combat_waits(self):
         task = NightmareNestTask.__new__(NightmareNestTask)
         task._capture_mode = True


### PR DESCRIPTION
## 修改内容

-将梦魇巢穴双选时的执行顺序从“梦魇拔除第一页 -> 梦魇拔除第二页 -> 残像聚落”调整为“残像聚落 -> 梦魇拔除第一页 -> 梦魇拔除第二页”。

## 修改原因

原逻辑会先执行 `go_nightmare`。进入梦魇拔除时，`open_boss_book('mengyan')` 会先点击分类栏底部，使左侧分类栏向下移动，然后再点击梦魇拔除。

分类栏移动后没有复位，后续 `go_nest` 仍按原始位置固定点击残像聚落。此时该坐标已经不再对应残像聚落，因此日志虽然记录了 `canxiang`，游戏页面实际没有正确切换，OCR 继续在错误页面查找，未找到未完成项后任务直接退出。

只勾选残像聚落时分类栏还处于初始位置，所以不会触发该问题。调整顺序后，程序会在分类栏被梦魇拔除移动前先完成残像聚落检查。

## 测试

本地测试均通过。
