### PR TITLE
fix: fall back to ONNX Runtime CPU after OpenVINO startup crash (#1504)

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,7 +7,9 @@ if 'PATH' not in os.environ:
     os.environ['PATH'] = ""
 from qfluentwidgets import FluentIcon
 
-from ok import Box, ConfigOption
+import pyappify
+from ok import Box, ConfigOption, get_path_relative_to_exe
+from src.openvino_guard import resolve_openvino_params
 from src.task.process_feature import process_feature
 
 version = "dev"
@@ -22,6 +24,17 @@ def blur_area(width, height):
     blur_width = int(0.12 * width)
     blur_height = int(0.024 * height)
     return Box(width * 0.879, height * 0.976, blur_width * 0.973, blur_height * 0.994)
+
+
+def ocr_accel_params():
+    # Only guard launcher-managed installs, where a crash-prone OpenVINO cannot be
+    # turned off permanently because updates overwrite config.py (#1504). Source
+    # runs and tests keep the static defaults, free of probe threads/state files.
+    if not pyappify.app_version:
+        return {'use_openvino': True, 'use_npu': True}
+    return resolve_openvino_params(
+        get_path_relative_to_exe('configs', 'openvino_state.json'),
+        pyappify.app_version)
 
 
 key_config_option = ConfigOption('Game Hotkey', {
@@ -59,10 +72,8 @@ config = {
     'ocr': {
         'lib': 'onnxocr',
         'auto_simplify': True,
-        'params': {
-            'use_openvino': True,
-            'use_npu': True,
-        }
+        # falls back to ONNX Runtime CPU when OpenVINO crashed a previous launch (#1504)
+        'params': ocr_accel_params(),
     },
     'my_app': ['src.globals', 'Globals'],
     'start_timeout': 120,  # default 60

--- a/config.py
+++ b/config.py
@@ -9,7 +9,7 @@ from qfluentwidgets import FluentIcon
 
 import pyappify
 from ok import Box, ConfigOption, get_path_relative_to_exe
-from src.openvino_guard import resolve_openvino_params
+from src import openvino_guard
 from src.task.process_feature import process_feature
 
 version = "dev"
@@ -31,8 +31,8 @@ def ocr_accel_params():
     # turned off permanently because updates overwrite config.py (#1504). Source
     # runs and tests keep the static defaults, free of probe threads/state files.
     if not pyappify.app_version:
-        return {'use_openvino': True, 'use_npu': True}
-    return resolve_openvino_params(
+        return dict(openvino_guard.ENABLED)
+    return openvino_guard.resolve_openvino_params(
         get_path_relative_to_exe('configs', 'openvino_state.json'),
         pyappify.app_version)
 

--- a/src/openvino_guard.py
+++ b/src/openvino_guard.py
@@ -1,0 +1,95 @@
+import atexit
+import json
+import logging
+import os
+import threading
+
+logger = logging.getLogger(__name__)
+
+STATUS_INITIALIZING = 'initializing'
+STATUS_OK = 'ok'
+STATUS_DISABLED = 'disabled'
+
+NOTE = 'Delete this file to retry OpenVINO acceleration.'
+
+_probe_done = False
+
+
+def resolve_openvino_params(state_file, version):
+    """Decide OCR acceleration params, remembering native OpenVINO crashes across runs.
+
+    openvino.Core() can die with a native access violation (0xc0000005) that
+    Python cannot catch, killing the whole app on startup (issue #1504). A
+    sentinel state file written before OpenVINO is first touched turns
+    "crashes on every launch" into "crashes at most once": if a launch dies
+    while the sentinel is still in place, the next launch falls back to ONNX
+    Runtime CPU and persists that decision. OpenVINO is retried once after
+    each app update, or when the user deletes the state file.
+    """
+    state = _read_state(state_file)
+    status = state.get('status')
+    if status == STATUS_DISABLED and state.get('version') == version:
+        logger.warning('OpenVINO disabled by previous failure: %s', state.get('reason'))
+        return {'use_openvino': False, 'use_npu': False}
+    if status == STATUS_INITIALIZING:
+        _write_state(state_file, STATUS_DISABLED, version,
+                     reason='app crashed during OpenVINO init on a previous launch')
+        logger.warning('previous launch crashed during OpenVINO init, falling back to ONNX Runtime CPU')
+        return {'use_openvino': False, 'use_npu': False}
+    _write_state(state_file, STATUS_INITIALIZING, version)
+    _start_probe(state_file, version)
+    return {'use_openvino': True, 'use_npu': True}
+
+
+def _start_probe(state_file, version):
+    atexit.register(_discard_unfinished_probe, state_file)
+    threading.Thread(target=_probe, args=(state_file, version),
+                     name='OpenVinoProbe', daemon=True).start()
+
+
+def _probe(state_file, version):
+    global _probe_done
+    try:
+        import openvino
+        # dies with 0xc0000005 here on broken drivers, leaving the sentinel behind
+        devices = openvino.Core().available_devices
+        logger.info('OpenVINO probe ok, devices: %s', devices)
+    except Exception as e:
+        _write_state(state_file, STATUS_DISABLED, version, reason=f'OpenVINO unusable: {e}')
+        logger.warning('OpenVINO probe failed, falling back to ONNX Runtime CPU on next launch: %s', e)
+        _probe_done = True
+        return
+    _write_state(state_file, STATUS_OK, version)
+    _probe_done = True
+
+
+def _discard_unfinished_probe(state_file):
+    # Clean exit before the probe concluded: no verdict, retry next launch.
+    # Racing a just-finished probe only deletes a fresh result, causing a
+    # harmless re-probe, so no lock is needed.
+    if not _probe_done:
+        try:
+            os.remove(state_file)
+        except OSError:
+            pass
+
+
+def _read_state(state_file):
+    try:
+        with open(state_file, encoding='utf-8') as f:
+            state = json.load(f)
+        return state if isinstance(state, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _write_state(state_file, status, version, reason=None):
+    try:
+        os.makedirs(os.path.dirname(state_file), exist_ok=True)
+        state = {'status': status, 'version': version, 'note': NOTE}
+        if reason:
+            state['reason'] = reason
+        with open(state_file, 'w', encoding='utf-8') as f:
+            json.dump(state, f, indent=2)
+    except OSError as e:
+        logger.warning('could not write OpenVINO state file %s: %s', state_file, e)

--- a/src/openvino_guard.py
+++ b/src/openvino_guard.py
@@ -31,10 +31,12 @@ def resolve_openvino_params(state_file, version):
     if state.get("version") == version:
         status = state.get("status")
         if status == STATUS_DISABLED:
-            logger.warning(
-                "OpenVINO disabled by previous failure: %s",
-                state.get("reason", "unknown"),
+            # state file is user-editable: strip line breaks so a crafted
+            # reason cannot forge extra log lines (SonarCloud S5145)
+            reason = (
+                str(state.get("reason", "unknown")).replace("\r", "").replace("\n", " ")
             )
+            logger.warning("OpenVINO disabled by previous failure: %s", reason)
             return dict(DISABLED)
         if status == STATUS_INITIALIZING:
             _write_state(

--- a/src/openvino_guard.py
+++ b/src/openvino_guard.py
@@ -6,13 +6,14 @@ import threading
 
 logger = logging.getLogger(__name__)
 
-STATUS_INITIALIZING = 'initializing'
-STATUS_OK = 'ok'
-STATUS_DISABLED = 'disabled'
+STATUS_INITIALIZING = "initializing"
+STATUS_OK = "ok"
+STATUS_DISABLED = "disabled"
 
-NOTE = 'Delete this file to retry OpenVINO acceleration.'
+ENABLED = {"use_openvino": True, "use_npu": True}
+DISABLED = {"use_openvino": False, "use_npu": False}
 
-_probe_done = False
+NOTE = "Delete this file to retry OpenVINO acceleration."
 
 
 def resolve_openvino_params(state_file, version):
@@ -27,69 +28,99 @@ def resolve_openvino_params(state_file, version):
     each app update, or when the user deletes the state file.
     """
     state = _read_state(state_file)
-    status = state.get('status')
-    if status == STATUS_DISABLED and state.get('version') == version:
-        logger.warning('OpenVINO disabled by previous failure: %s', state.get('reason'))
-        return {'use_openvino': False, 'use_npu': False}
-    if status == STATUS_INITIALIZING:
-        _write_state(state_file, STATUS_DISABLED, version,
-                     reason='app crashed during OpenVINO init on a previous launch')
-        logger.warning('previous launch crashed during OpenVINO init, falling back to ONNX Runtime CPU')
-        return {'use_openvino': False, 'use_npu': False}
+    if state.get("version") == version:
+        status = state.get("status")
+        if status == STATUS_DISABLED:
+            logger.warning(
+                "OpenVINO disabled by previous failure: %s",
+                state.get("reason", "unknown"),
+            )
+            return dict(DISABLED)
+        if status == STATUS_INITIALIZING:
+            _write_state(
+                state_file,
+                STATUS_DISABLED,
+                version,
+                reason="app crashed during OpenVINO init on a previous launch",
+            )
+            logger.warning(
+                "previous launch crashed during OpenVINO init, falling back to ONNX Runtime CPU"
+            )
+            return dict(DISABLED)
+    # fresh install, new app version, or last probe succeeded: (re)probe
     _write_state(state_file, STATUS_INITIALIZING, version)
     _start_probe(state_file, version)
-    return {'use_openvino': True, 'use_npu': True}
+    return dict(ENABLED)
 
 
 def _start_probe(state_file, version):
-    atexit.register(_discard_unfinished_probe, state_file)
-    threading.Thread(target=_probe, args=(state_file, version),
-                     name='OpenVinoProbe', daemon=True).start()
+    concluded = threading.Event()
+    atexit.register(_discard_unfinished_probe, state_file, concluded)
+    threading.Thread(
+        target=_probe,
+        args=(state_file, version, concluded),
+        name="OpenVinoProbe",
+        daemon=True,
+    ).start()
 
 
-def _probe(state_file, version):
-    global _probe_done
+def _probe(state_file, version, concluded):
     try:
         import openvino
+
         # dies with 0xc0000005 here on broken drivers, leaving the sentinel behind
         devices = openvino.Core().available_devices
-        logger.info('OpenVINO probe ok, devices: %s', devices)
+        logger.info("OpenVINO probe ok, devices: %s", devices)
     except Exception as e:
-        _write_state(state_file, STATUS_DISABLED, version, reason=f'OpenVINO unusable: {e}')
-        logger.warning('OpenVINO probe failed, falling back to ONNX Runtime CPU on next launch: %s', e)
-        _probe_done = True
+        if _write_state(
+            state_file, STATUS_DISABLED, version, reason=f"OpenVINO unusable: {e}"
+        ):
+            concluded.set()
+        logger.warning(
+            "OpenVINO probe failed, falling back to ONNX Runtime CPU on next launch: %s",
+            e,
+        )
         return
-    _write_state(state_file, STATUS_OK, version)
-    _probe_done = True
+    if _write_state(state_file, STATUS_OK, version):
+        concluded.set()
 
 
-def _discard_unfinished_probe(state_file):
-    # Clean exit before the probe concluded: no verdict, retry next launch.
-    # Racing a just-finished probe only deletes a fresh result, causing a
-    # harmless re-probe, so no lock is needed.
-    if not _probe_done:
-        try:
-            os.remove(state_file)
-        except OSError:
-            pass
+def _discard_unfinished_probe(state_file, concluded):
+    # Clean exit before the probe concluded (or before its verdict reached
+    # disk): no verdict, drop the sentinel and retry next launch. Racing a
+    # just-finished probe only deletes a fresh result, causing a harmless
+    # re-probe, so no lock is needed.
+    if concluded.is_set():
+        return
+    try:
+        os.remove(state_file)
+    except FileNotFoundError:
+        pass
+    except OSError as e:
+        logger.warning("could not discard OpenVINO sentinel %s: %s", state_file, e)
 
 
 def _read_state(state_file):
     try:
-        with open(state_file, encoding='utf-8') as f:
+        with open(state_file, encoding="utf-8") as f:
             state = json.load(f)
         return state if isinstance(state, dict) else {}
-    except (OSError, ValueError):
+    except FileNotFoundError:
+        return {}
+    except (OSError, ValueError) as e:
+        logger.warning("ignoring unreadable OpenVINO state file %s: %s", state_file, e)
         return {}
 
 
 def _write_state(state_file, status, version, reason=None):
     try:
         os.makedirs(os.path.dirname(state_file), exist_ok=True)
-        state = {'status': status, 'version': version, 'note': NOTE}
+        state = {"status": status, "version": version, "note": NOTE}
         if reason:
-            state['reason'] = reason
-        with open(state_file, 'w', encoding='utf-8') as f:
+            state["reason"] = reason
+        with open(state_file, "w", encoding="utf-8") as f:
             json.dump(state, f, indent=2)
+        return True
     except OSError as e:
-        logger.warning('could not write OpenVINO state file %s: %s', state_file, e)
+        logger.warning("could not write OpenVINO state file %s: %s", state_file, e)
+        return False

--- a/tests/TestOpenVinoGuard.py
+++ b/tests/TestOpenVinoGuard.py
@@ -1,5 +1,6 @@
 import json
 import sys
+import threading
 import types
 import unittest
 from pathlib import Path
@@ -9,17 +10,12 @@ from unittest.mock import patch
 
 import src.openvino_guard as guard
 
-ENABLED = {'use_openvino': True, 'use_npu': True}
-DISABLED = {'use_openvino': False, 'use_npu': False}
-
 
 class TestOpenVinoGuard(unittest.TestCase):
-
     def setUp(self):
         tmp = TemporaryDirectory()
         self.addCleanup(tmp.cleanup)
-        self.state_file = str(Path(tmp.name) / 'configs' / 'openvino_state.json')
-        guard._probe_done = False
+        self.state_file = str(Path(tmp.name) / "configs" / "openvino_state.json")
 
     def read_state(self):
         return json.loads(Path(self.state_file).read_text())
@@ -29,81 +25,104 @@ class TestOpenVinoGuard(unittest.TestCase):
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(kwargs))
 
-    def resolve(self, version='1.0'):
-        with patch.object(guard, '_start_probe') as start_probe:
+    def resolve(self, version="1.0"):
+        with patch.object(guard, "_start_probe") as start_probe:
             result = guard.resolve_openvino_params(self.state_file, version)
         return result, start_probe
 
     def test_first_launch_enables_openvino_and_writes_sentinel(self):
         result, start_probe = self.resolve()
-        self.assertEqual(ENABLED, result)
-        self.assertEqual(guard.STATUS_INITIALIZING, self.read_state()['status'])
+        self.assertEqual(guard.ENABLED, result)
+        self.assertEqual(guard.STATUS_INITIALIZING, self.read_state()["status"])
         start_probe.assert_called_once()
 
     def test_leftover_sentinel_disables_openvino(self):
-        self.write_state(status=guard.STATUS_INITIALIZING, version='1.0')
+        self.write_state(status=guard.STATUS_INITIALIZING, version="1.0")
         result, start_probe = self.resolve()
-        self.assertEqual(DISABLED, result)
-        self.assertEqual(guard.STATUS_DISABLED, self.read_state()['status'])
+        self.assertEqual(guard.DISABLED, result)
+        self.assertEqual(guard.STATUS_DISABLED, self.read_state()["status"])
         start_probe.assert_not_called()
 
+    def test_leftover_sentinel_from_old_version_retries(self):
+        self.write_state(status=guard.STATUS_INITIALIZING, version="1.0")
+        result, start_probe = self.resolve(version="2.0")
+        self.assertEqual(guard.ENABLED, result)
+        self.assertEqual(guard.STATUS_INITIALIZING, self.read_state()["status"])
+        start_probe.assert_called_once()
+
     def test_disabled_state_stays_disabled_for_same_version(self):
-        self.write_state(status=guard.STATUS_DISABLED, version='1.0')
-        result, start_probe = self.resolve(version='1.0')
-        self.assertEqual(DISABLED, result)
+        self.write_state(status=guard.STATUS_DISABLED, version="1.0")
+        result, start_probe = self.resolve(version="1.0")
+        self.assertEqual(guard.DISABLED, result)
         start_probe.assert_not_called()
 
     def test_disabled_state_retries_after_app_update(self):
-        self.write_state(status=guard.STATUS_DISABLED, version='1.0')
-        result, start_probe = self.resolve(version='2.0')
-        self.assertEqual(ENABLED, result)
-        self.assertEqual(guard.STATUS_INITIALIZING, self.read_state()['status'])
+        self.write_state(status=guard.STATUS_DISABLED, version="1.0")
+        result, start_probe = self.resolve(version="2.0")
+        self.assertEqual(guard.ENABLED, result)
+        self.assertEqual(guard.STATUS_INITIALIZING, self.read_state()["status"])
         start_probe.assert_called_once()
 
     def test_ok_state_probes_again(self):
-        self.write_state(status=guard.STATUS_OK, version='1.0')
+        self.write_state(status=guard.STATUS_OK, version="1.0")
         result, start_probe = self.resolve()
-        self.assertEqual(ENABLED, result)
-        self.assertEqual(guard.STATUS_INITIALIZING, self.read_state()['status'])
+        self.assertEqual(guard.ENABLED, result)
+        self.assertEqual(guard.STATUS_INITIALIZING, self.read_state()["status"])
         start_probe.assert_called_once()
 
     def test_corrupt_state_treated_as_first_launch(self):
         path = Path(self.state_file)
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text('not json {')
+        path.write_text("not json {")
         result, start_probe = self.resolve()
-        self.assertEqual(ENABLED, result)
-        self.assertEqual(guard.STATUS_INITIALIZING, self.read_state()['status'])
+        self.assertEqual(guard.ENABLED, result)
+        self.assertEqual(guard.STATUS_INITIALIZING, self.read_state()["status"])
         start_probe.assert_called_once()
 
-    def test_probe_success_writes_ok(self):
-        fake = types.ModuleType('openvino')
-        fake.Core = lambda: SimpleNamespace(available_devices=['CPU'])
-        with patch.dict(sys.modules, {'openvino': fake}):
-            guard._probe(self.state_file, '1.0')
+    def test_probe_success_writes_ok_and_concludes(self):
+        concluded = threading.Event()
+        fake = types.ModuleType("openvino")
+        fake.Core = lambda: SimpleNamespace(available_devices=["CPU"])
+        with patch.dict(sys.modules, {"openvino": fake}):
+            guard._probe(self.state_file, "1.0", concluded)
         state = self.read_state()
-        self.assertEqual(guard.STATUS_OK, state['status'])
-        self.assertEqual('1.0', state['version'])
-        self.assertTrue(guard._probe_done)
+        self.assertEqual(guard.STATUS_OK, state["status"])
+        self.assertEqual("1.0", state["version"])
+        self.assertTrue(concluded.is_set())
 
     def test_probe_import_failure_writes_disabled(self):
-        with patch.dict(sys.modules, {'openvino': None}):
-            guard._probe(self.state_file, '1.0')
-        self.assertEqual(guard.STATUS_DISABLED, self.read_state()['status'])
-        self.assertTrue(guard._probe_done)
+        concluded = threading.Event()
+        with patch.dict(sys.modules, {"openvino": None}):
+            guard._probe(self.state_file, "1.0", concluded)
+        self.assertEqual(guard.STATUS_DISABLED, self.read_state()["status"])
+        self.assertTrue(concluded.is_set())
+
+    def test_probe_does_not_conclude_when_verdict_write_fails(self):
+        concluded = threading.Event()
+        fake = types.ModuleType("openvino")
+        fake.Core = lambda: SimpleNamespace(available_devices=["CPU"])
+        with (
+            patch.dict(sys.modules, {"openvino": fake}),
+            patch.object(guard, "_write_state", return_value=False),
+        ):
+            guard._probe(self.state_file, "1.0", concluded)
+        self.assertFalse(concluded.is_set())
 
     def test_clean_exit_before_probe_verdict_discards_sentinel(self):
-        self.write_state(status=guard.STATUS_INITIALIZING, version='1.0')
-        guard._probe_done = False
-        guard._discard_unfinished_probe(self.state_file)
+        self.write_state(status=guard.STATUS_INITIALIZING, version="1.0")
+        guard._discard_unfinished_probe(self.state_file, threading.Event())
         self.assertFalse(Path(self.state_file).exists())
 
-    def test_clean_exit_keeps_finished_probe_result(self):
-        self.write_state(status=guard.STATUS_OK, version='1.0')
-        guard._probe_done = True
-        guard._discard_unfinished_probe(self.state_file)
+    def test_clean_exit_keeps_concluded_probe_result(self):
+        self.write_state(status=guard.STATUS_OK, version="1.0")
+        concluded = threading.Event()
+        concluded.set()
+        guard._discard_unfinished_probe(self.state_file, concluded)
         self.assertTrue(Path(self.state_file).exists())
 
+    def test_discard_tolerates_missing_file(self):
+        guard._discard_unfinished_probe(self.state_file, threading.Event())
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/TestOpenVinoGuard.py
+++ b/tests/TestOpenVinoGuard.py
@@ -1,0 +1,109 @@
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import src.openvino_guard as guard
+
+ENABLED = {'use_openvino': True, 'use_npu': True}
+DISABLED = {'use_openvino': False, 'use_npu': False}
+
+
+class TestOpenVinoGuard(unittest.TestCase):
+
+    def setUp(self):
+        tmp = TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.state_file = str(Path(tmp.name) / 'configs' / 'openvino_state.json')
+        guard._probe_done = False
+
+    def read_state(self):
+        return json.loads(Path(self.state_file).read_text())
+
+    def write_state(self, **kwargs):
+        path = Path(self.state_file)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(kwargs))
+
+    def resolve(self, version='1.0'):
+        with patch.object(guard, '_start_probe') as start_probe:
+            result = guard.resolve_openvino_params(self.state_file, version)
+        return result, start_probe
+
+    def test_first_launch_enables_openvino_and_writes_sentinel(self):
+        result, start_probe = self.resolve()
+        self.assertEqual(ENABLED, result)
+        self.assertEqual(guard.STATUS_INITIALIZING, self.read_state()['status'])
+        start_probe.assert_called_once()
+
+    def test_leftover_sentinel_disables_openvino(self):
+        self.write_state(status=guard.STATUS_INITIALIZING, version='1.0')
+        result, start_probe = self.resolve()
+        self.assertEqual(DISABLED, result)
+        self.assertEqual(guard.STATUS_DISABLED, self.read_state()['status'])
+        start_probe.assert_not_called()
+
+    def test_disabled_state_stays_disabled_for_same_version(self):
+        self.write_state(status=guard.STATUS_DISABLED, version='1.0')
+        result, start_probe = self.resolve(version='1.0')
+        self.assertEqual(DISABLED, result)
+        start_probe.assert_not_called()
+
+    def test_disabled_state_retries_after_app_update(self):
+        self.write_state(status=guard.STATUS_DISABLED, version='1.0')
+        result, start_probe = self.resolve(version='2.0')
+        self.assertEqual(ENABLED, result)
+        self.assertEqual(guard.STATUS_INITIALIZING, self.read_state()['status'])
+        start_probe.assert_called_once()
+
+    def test_ok_state_probes_again(self):
+        self.write_state(status=guard.STATUS_OK, version='1.0')
+        result, start_probe = self.resolve()
+        self.assertEqual(ENABLED, result)
+        self.assertEqual(guard.STATUS_INITIALIZING, self.read_state()['status'])
+        start_probe.assert_called_once()
+
+    def test_corrupt_state_treated_as_first_launch(self):
+        path = Path(self.state_file)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('not json {')
+        result, start_probe = self.resolve()
+        self.assertEqual(ENABLED, result)
+        self.assertEqual(guard.STATUS_INITIALIZING, self.read_state()['status'])
+        start_probe.assert_called_once()
+
+    def test_probe_success_writes_ok(self):
+        fake = types.ModuleType('openvino')
+        fake.Core = lambda: SimpleNamespace(available_devices=['CPU'])
+        with patch.dict(sys.modules, {'openvino': fake}):
+            guard._probe(self.state_file, '1.0')
+        state = self.read_state()
+        self.assertEqual(guard.STATUS_OK, state['status'])
+        self.assertEqual('1.0', state['version'])
+        self.assertTrue(guard._probe_done)
+
+    def test_probe_import_failure_writes_disabled(self):
+        with patch.dict(sys.modules, {'openvino': None}):
+            guard._probe(self.state_file, '1.0')
+        self.assertEqual(guard.STATUS_DISABLED, self.read_state()['status'])
+        self.assertTrue(guard._probe_done)
+
+    def test_clean_exit_before_probe_verdict_discards_sentinel(self):
+        self.write_state(status=guard.STATUS_INITIALIZING, version='1.0')
+        guard._probe_done = False
+        guard._discard_unfinished_probe(self.state_file)
+        self.assertFalse(Path(self.state_file).exists())
+
+    def test_clean_exit_keeps_finished_probe_result(self):
+        self.write_state(status=guard.STATUS_OK, version='1.0')
+        guard._probe_done = True
+        guard._discard_unfinished_probe(self.state_file)
+        self.assertTrue(Path(self.state_file).exists())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# PR 说明 / PR Description

Fixes #1504

## 修改内容 / Changes

- `openvino.Core()` 在部分机器上会在原生层触发 0xc0000005（访问冲突），Python 无法捕获，导致程序每次启动直接退出（#1504）。由于更新会覆盖 `config.py`，用户手动改 `use_openvino=False` 的临时方案每次更新后都会失效。
- 新增 `src/openvino_guard.py`：在首次接触 OpenVINO 之前，先把 `initializing` 哨兵写入 `configs/openvino_state.json`（`configs/` 跨更新保留），随后由后台线程探测 `openvino.Core()`，成功则改写为 `ok`。如果某次启动在哨兵仍在时硬崩溃，下次启动会自动改用 ONNX Runtime CPU 并持久化 `disabled`，把"每次启动必崩"变成"最多崩溃一次，之后自动回退"。
- 每次版本更新后自动重试一次 OpenVINO（更新可能带来修复的运行时/驱动兼容性）；用户删除状态文件也可手动重试。
- 防护只在 pyappify launcher 启动时生效（`PYAPPIFY_APP_VERSION` 存在）；从源码运行和测试保持原有静态默认值，不写任何文件、不启动探测线程。
- 运行时 `ocr.params` 的结构不变（仍是 `use_openvino`/`use_npu` 两个布尔值），只是取值方式改变；`src/globals.py` 的 YOLO 模型选择读同一旗标，因此 OCR 与 YOLO 两条 OpenVINO 路径同时被覆盖。

English summary: `openvino.Core()` can die with a native access violation (0xc0000005) that Python cannot catch, killing the app on every launch, and updates overwrite `config.py` so the user's manual `use_openvino=False` workaround never sticks. This PR writes a sentinel state file (in `configs/`, which survives updates) before OpenVINO is first touched and confirms it with a background probe; if a launch dies while the sentinel is in place, the next launch falls back to ONNX Runtime CPU and persists that decision. OpenVINO is retried once after each app update or when the user deletes the state file. Only launcher-managed runs are guarded; source runs and tests keep the static defaults. The runtime shape of `ocr.params` is unchanged.

## 修改类型 / Type of Change

- [x] Bug 修复 / Bug fix
- [ ] 文档或翻译 / Documentation or translation
- [ ] 小型优化或兼容性修复 / Small improvement or compatibility fix
- [ ] 新功能 / New feature
- [ ] 大幅修改现有功能 / Major modification of existing behavior
- [ ] 重构或架构调整 / Refactor or architecture change

## 新功能或大改确认 / New Feature or Major Change Confirmation

- [x] 不适用，本 PR 不是新功能或大改 / Not applicable; this PR is not a new feature or major change
- [ ] 已联系作者或已在社区讨论 / I have contacted the author or discussed this in the community

相关讨论链接或联系方式说明：

- #1504

## 测试 / Testing

- 新增 `tests/TestOpenVinoGuard.py`，13 个单元测试覆盖状态机全部分支（首次启动、哨兵残留、同版本保持禁用、更新后重试、旧版本哨兵重试、损坏状态文件、探测成功/失败、写盘失败不误标结论、干净退出清理哨兵等），仅依赖标准库，`python -m unittest tests/TestOpenVinoGuard.py` 全部通过，CI 的 windows-latest 也会运行。
- 用桩模块（stub `ok`/`pyappify`/`qfluentwidgets`）模拟完整 `config.py` 导入流程验证两种模式：launcher 模式下探测失败 → 状态持久化 → 第二次启动返回 `use_openvino=False`；源码模式下保持静态默认且不写状态文件。
- 无法测试的部分：开发机（Linux）无法复现 Windows 上的原生 NPU 崩溃，"崩溃后下次启动自动回退"的端到端行为需要 #1504 报告者所在环境验证。逻辑上该场景等价于"哨兵残留"分支，已被单元测试覆盖。

## 截图或录屏 / Screenshots or Recordings

不适用：无 UI 变化，仅在日志中新增回退警告（如 `previous launch crashed during OpenVINO init, falling back to ONNX Runtime CPU`）。

## 检查清单 / Checklist

- [x] 我已阅读 [CONTRIBUTING.md](https://github.com/ok-oldking/ok-wuthering-waves/blob/master/CONTRIBUTING.md) / I have read [CONTRIBUTING.md](https://github.com/ok-oldking/ok-wuthering-waves/blob/master/CONTRIBUTING.md)
- [x] 我已阅读 README 中的免责声明 / I have read the disclaimer in the README
- [x] 我已尽量保持 PR 范围清晰，没有混入无关修改 / I have kept this PR focused and avoided unrelated changes
- [x] 我已说明测试结果或无法测试的原因 / I have described the test results or why testing was not possible
- [x] 我没有提交日志、缓存、临时文件或个人配置 / I have not committed logs, caches, temporary files, or personal settings
