### PR TITLE
fix(NightmareNestTask): 日常声骸模式获取后先退本再结束

### DIFF
--- a/src/task/NightmareNestTask.py
+++ b/src/task/NightmareNestTask.py
@@ -104,19 +104,21 @@ class NightmareNestTask(WWOneTimeTask, BaseCombatTask):
         except CharRevivedException:
             self.log_info('nightmare nest: death recovered, re-enter from F2 book')
             return
+        captured_early = False
         if self._capture_mode:
             if self._capture_success or self.wait_until(self.has_echo_notification, time_out=3):
                 self.log_info("Captured echo during combat, skipping search.")
-                return
-        else:
+                captured_early = True
+        if not captured_early:
             self.sleep(3)
-        if need_find and not self.walk_find_echo(time_out=5, backward_time=2.5):
-            dropped = self.yolo_find_echo(turn=True, use_color=False, time_out=30)[0]
-            logger.info(f'farm echo yolo find {dropped}')
-        else:
-            dropped = True
-            self.log_info(f'farm echo walk find true')
-        self._capture_success = dropped
+            if need_find and not self.walk_find_echo(time_out=5, backward_time=2.5):
+                dropped = self.yolo_find_echo(turn=True, use_color=False, time_out=30)[0]
+                logger.info(f'farm echo yolo find {dropped}')
+            else:
+                dropped = True
+                self.log_info(f'farm echo walk find true')
+            self._capture_success = dropped
+        # 与刷全部一致：退本后再结束 combat_nest，避免还在巢穴内回 Daily/开书
         if is_team:
             self.send_key('esc', after_sleep=1)
             self.click(0.652, 0.628, after_sleep=2)


### PR DESCRIPTION
## Summary
针对一条龙中，没勾选“自动刷所有梦魇巢穴”时，只勾选“使用梦魇巢穴获取日常声骸“的情况，适配了新版本必须要先退出再进行下一步日常流程。
- 日常声骸（`run_capture_mode`）战斗中捡到声骸后不再提前 `return`
- 与「刷全部」对齐：先走 `is_team` 退本 + `sleep(1)`，再结束 `combat_nest` / `break` 回 Daily
- 避免仍在梦魇巢穴内开书/进后续流程导致卡死（新版本巢穴内无法 F2）