### PR TITLE
秧秧-玄翎的声骸无法释放问题修复

### DIFF
--- a/src/char/YangYangSp.py
+++ b/src/char/YangYangSp.py
@@ -24,6 +24,7 @@ class YangYangSp(BaseChar):
     def do_perform(self):
         duration = self.INTRO_PERFORM_DURATION if self.has_intro else self.PERFORM_DURATION
         start = time.time()
+        self.click_echo(time_out=0)
         self.task.mouse_down()
         resonance_available = 0
         try:

--- a/tests/TestChar.py
+++ b/tests/TestChar.py
@@ -125,6 +125,10 @@ class TestChar(TaskTestCase):
                 actions.append(('sleep', duration))
 
         class TrackingYangYangSp(YangYangSp):
+            def click_echo(self, duration=0, sleep_time=0, time_out=1):
+                actions.append(('echo', time_out))
+                return True
+
             def time_elapsed_accounting_for_freeze(self, start, intro_motion_freeze=False):
                 return self.PERFORM_DURATION
 
@@ -135,6 +139,7 @@ class TestChar(TaskTestCase):
         yangyang.do_perform()
 
         self.assertEqual(actions, [
+            ('echo', 0),
             'mouse_down',
             'mouse_up',
             ('sleep', YangYangSp.LONG_PRESS_RELEASE_DELAY),


### PR DESCRIPTION
# PR 说明 / PR Description

## 修改内容 / Changes

Please briefly describe what this PR changes.

- 临时修复 https://github.com/ok-oldking/ok-wuthering-waves/issues/1516 提到的问题
- 调整test逻辑，补充声骸调用验证

## 修改类型 / Type of Change

请选择适用项：

Please check all that apply:

- [x] Bug 修复 / Bug fix
- [ ] 文档或翻译 / Documentation or translation
- [ ] 小型优化或兼容性修复 / Small improvement or compatibility fix
- [ ] 新功能 / New feature
- [ ] 大幅修改现有功能 / Major modification of existing behavior
- [ ] 重构或架构调整 / Refactor or architecture change

## 新功能或大改确认 / New Feature or Major Change Confirmation

如果本 PR 包含新功能，或会大幅修改当前功能、任务行为、角色逻辑、识别逻辑、配置结构或用户体验，请先联系作者或在社区中讨论后再提交。

If this PR adds a new feature, or significantly changes existing features, task behavior, character logic, recognition logic, configuration structure, or user experience, please contact the author or discuss it with the community before submitting.

- [x] 不适用，本 PR 不是新功能或大改 / Not applicable; this PR is not a new feature or major change
- [ ] 已联系作者或已在社区讨论 / I have contacted the author or discussed this in the community

相关讨论链接或联系方式说明：

Related discussion link or contact note:

- 

## 测试 / Testing

请说明你运行过的测试、验证步骤或无法测试的原因。

Please describe the tests, verification steps, or why testing could not be completed.

- 运行python -m unittest tests\TestChar.py，原测试文件无法测试声骸释放，调整测试逻辑后通过。
    - 留存一个现有问题：ERROR: test_switch_cd (tests.TestChar.TestChar.test_switch_cd)，不在本次修改范围内，不作调整

## 截图或录屏 / Screenshots or Recordings

如果修改会影响界面、识别结果或用户可见行为，请补充截图或录屏。

If the change affects UI, recognition results, or user-visible behavior, please include screenshots or recordings.

- [秧秧声骸释放修复.mp4](https://pan.baidu.com/s/171e-hyajbCXPcIOYxoVpkA?pwd=hpp9) 提取码: hpp9 ，第15s处，声骸可以成功释放

## 检查清单 / Checklist

- [x] 我已阅读 [CONTRIBUTING.md](https://github.com/ok-oldking/ok-wuthering-waves/blob/master/CONTRIBUTING.md) / I have read [CONTRIBUTING.md](https://github.com/ok-oldking/ok-wuthering-waves/blob/master/CONTRIBUTING.md)
- [x] 我已阅读 README 中的免责声明 / I have read the disclaimer in the README
- [x] 我已尽量保持 PR 范围清晰，没有混入无关修改 / I have kept this PR focused and avoided unrelated changes
- [x] 我已说明测试结果或无法测试的原因 / I have described the test results or why testing was not possible
- [x] 我没有提交日志、缓存、临时文件或个人配置 / I have not committed logs, caches, temporary files, or personal settings

## 社区联系方式 / Community Contact

- 开发者群 / Developer QQ group: `926858895`
- Discord: [https://discord.gg/vVyCatEBgA](https://discord.gg/vVyCatEBgA)
