### PR TITLE
fix: 修复战歌重奏第4个Boss索引越界 & 添加90级Boss等级选项

### DIFF
--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -1189,7 +1189,23 @@ class BaseWWTask(BaseTask):
         if not btns:
             raise Exception("can't find boss_proceed")
         if target_index > -1:
-            target = btns[target_index]
+            if target_index < len(btns):
+                target = btns[target_index]
+            else:
+                # Fallback: not enough visible rows, scroll to bring target into view
+                container_h = bar_bottom - bar_top
+                if structure:
+                    cross_count = get_cross_count(structure, serial_number)
+                    cross_count += 1
+                    container_h -= len(structure) * separator
+                item_h = container_h / total_number
+                height = item_h * serial_number
+                to_click_y = min(bar_top + height + cross_count * separator, bar_bottom)
+                self.click(bar_x, to_click_y, after_sleep=1)
+                btns = self.find_feature('boss_proceed', box=self.box_of_screen(0.9113, 0.229, 0.9613, 0.861), threshold=0.8)
+                if not btns:
+                    raise Exception("can't find boss_proceed after scroll")
+                target = max(btns, key=lambda box: box.y)
         else:
             target = max(btns, key=lambda box: box.y)
         self.draw_boxes(boxes=target, color="red")

--- a/src/task/FarmEchoTask.py
+++ b/src/task/FarmEchoTask.py
@@ -49,7 +49,7 @@ class FarmEchoTask(WWOneTimeTask, BaseCombatTask):
                                                     'Boss Challenge': ['Which Boss Challenge to Teleport',
                                                                        'Boss Level'],
                                                 }}
-        self.config_type['Boss Level'] = {'type': "drop_down", 'options': ['50', '60', '70', '80'], }
+        self.config_type['Boss Level'] = {'type': "drop_down", 'options': ['50', '60', '70', '80', '90'], }
         self.config_type['Echo Pickup Method'] = {'type': "drop_down", 'options': self.find_echo_method}
         self.boss_list = ['Other', 'Hyvatia', 'Fallacy of No Return', 'Sentry Construct', 'Lorelei', 'Lioness of Glory',
                           'Nightmare: Hecate', 'Fenrico', 'Nameless Explorer']


### PR DESCRIPTION
本人不会写代码，在使用过程中遇到问题，由 AI 全程自动分析、定位和修改。

---

## 问题描述

### 问题1：战歌重奏 + 第4个Boss 传送报错

`副本/大世界刷4C声骸` -> `传送至BOSS` -> 选择`战歌重奏` -> 第4个Boss，脚本报错 `RuntimeError: Teleport to boss failed`

**日志错误：** `IndexError: list index out of range` at `BaseWWTask.py:1152`

**根因：** `click_on_book_target` 方法硬编码 `container_max_rows = 4`，假设一屏可见4行。战歌重奏(zhange)页面每个条目比讨伐强敌(qiangdi)更高，一屏仅显示约3行，导致选第4个Boss时 `btns[3]` 越界。

**修复：** 在 target_index 超过 len(btns) 时，自动降级为滚动+重新识别方案。对所有原有正常场景零影响。

### 问题2：Boss等级仅支持到80级

下拉框选项仅 50/60/70/80，游戏已有90级。添加90级支持。

## 修改文件

- `src/task/BaseWWTask.py` — fallback 滚动逻辑
- `src/task/FarmEchoTask.py` — 增加 90 级选项

Co-Authored-By: Claude <noreply@anthropic.com>