### PR TITLE
feat: 残像聚落未收取声骸时重新传送保底（issue #1571）

### DIFF
--- a/src/task/NightmareNestTask.py
+++ b/src/task/NightmareNestTask.py
@@ -32,6 +32,7 @@ class NightmareNestTask(WWOneTimeTask, BaseCombatTask):
         self._capture_success = False
         self._capture_mode = False
         self._unreachable_nests = set()
+        self._nest_tab_of_current_nest = 'go_nest'
         self.default_config.update({'Which to Farm': ['Nightmare Purification', 'Tacet Discord Nest']})
         self.config_type['Which to Farm'] = {'type': "multi_selection",
                                              'options': ['Nightmare Purification', 'Tacet Discord Nest']}
@@ -112,6 +113,24 @@ class NightmareNestTask(WWOneTimeTask, BaseCombatTask):
                 if need_find and not self.walk_find_echo(time_out=5, backward_time=2.5):
                     dropped = self.yolo_find_echo(turn=True, use_color=False, time_out=30)[0]
                     logger.info(f'farm echo yolo find {dropped}')
+                    if not dropped and not is_team:
+                        # 保底：没有收取到声骸时，重新打开图鉴传送回当前聚落（传送点面朝金色声骸群），再搜索一次
+                        self.log_info('no echo collected, re-teleport to current nest as fallback')
+                        self.ensure_main(time_out=30)
+                        self.openF2Book("gray_book_boss")
+                        getattr(self, self._nest_tab_of_current_nest)()
+                        self.sleep(1)
+                        self.click(target_box, after_sleep=2)
+                        if self.wait_feature(TRAVEL_FEATURES, time_out=5, settle_time=0.5,
+                                            raise_if_not_found=False) and self._travel_to_nest_or_skip(nest):
+                            self.sleep(2)
+                            self.run_until(lambda: False, 'w', time_out=2, running=True)
+                            if not self.walk_find_echo(time_out=5, backward_time=2.5):
+                                dropped = self.yolo_find_echo(turn=True, use_color=False, time_out=30)[0]
+                                logger.info(f'farm echo yolo find after re-teleport {dropped}')
+                            else:
+                                dropped = True
+                                self.log_info('farm echo walk find true after re-teleport')
                 else:
                     dropped = True
                     self.log_info(f'farm echo walk find true')
@@ -163,6 +182,7 @@ class NightmareNestTask(WWOneTimeTask, BaseCombatTask):
         while self.queues:
             self.queues[0]()
             if nest := self.find_nest():
+                self._nest_tab_of_current_nest = self.queues[0].__name__
                 return nest
             self.queues.pop(0)
 


### PR DESCRIPTION
对应 issue: https://github.com/ok-oldking/ok-wuthering-waves/issues/1571（残像聚落的声骸吸收成功率过低）

## 背景

残像聚落/梦魇聚落打完怪物后，如果搜索都没能收取到声骸，当前版本会直接跳过该聚落。旧版本（v2.6.12 ~ v2.8.18）有一个保底操作：**没有收取到声骸时，重新传送回当前聚落（传送点固定面朝金色声骸群），再搜索一次**，该逻辑在 v3.0.0 重构时随导航机制一并移除。

## 本 PR 改动

在 `NightmareNestTask.combat_nest` 中恢复该保底：搜索失败后，自动：
1. 重新打开图鉴（F2 → 怪物图鉴 → 对应标签页，沿用 `find_nest` 时的来源标签页）
2. 点击当前聚落条目 → 快速旅行传送回当前聚落
3. 向前冲刺后再次搜索，尝试收取声骸

实现未照搬旧代码，而是适配当前版本已重写的 UI 机制：
- `openF2Book("gray_book_boss")` + `getattr(self, self._nest_tab_of_current_nest)()` 代替旧版搜索
- `wait_feature(TRAVEL_FEATURES)` + `_travel_to_nest_or_skip()` 代替旧版固定坐标点击传送
- 传送失败时静默跳过，不影响后续聚落

改动仅 1 个文件，+20/-0。

## 实测

- 保底触发：`no echo collected, re-teleport to current nest as fallback`
- 重传后成功吸收：`farm echo walk find true`（has_claim 确认）
