### PR TITLE
main.py/main_debug.py: 启用 faulthandler 崩溃诊断

### DIFF
--- a/faulthandler_setup.py
+++ b/faulthandler_setup.py
@@ -1,0 +1,22 @@
+"""Enable faulthandler for crash diagnostics.
+
+The packaged app runs as pythonw.exe which has no console, so fatal native
+errors (e.g. access violations in graphics backends) used to kill the process
+silently.  Importing this module writes every thread's Python stack to
+logs/ok-ww_fault.log on such failures.
+"""
+import faulthandler
+import os
+import signal
+
+_fault_log = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'logs', 'ok-ww_fault.log')
+try:
+    os.makedirs(os.path.dirname(_fault_log), exist_ok=True)
+    _fault_file = open(_fault_log, 'a', encoding='utf-8')
+    faulthandler.enable(file=_fault_file)
+    faulthandler.register(signal.SIGSEGV, file=_fault_file)
+except Exception:
+    try:
+        faulthandler.enable()
+    except Exception:
+        pass

--- a/main.py
+++ b/main.py
@@ -1,3 +1,8 @@
+# Crash diagnostics: pythonw has no console, so faulthandler writes fatal
+# stacks to logs/ok-ww_fault.log (see faulthandler_setup.py).
+import faulthandler_setup  # noqa: F401
+
+
 if __name__ == '__main__':
     from config import config
     from ok import OK

--- a/main_debug.py
+++ b/main_debug.py
@@ -1,6 +1,11 @@
 import os
 
 os.environ["PYAPPIFY_PYTHON_TEST"] = "1"
+
+# Same crash diagnostics as main.py (see faulthandler_setup.py).
+import faulthandler_setup  # noqa: F401
+
+
 if __name__ == '__main__':
     from config import config
     from ok import OK


### PR DESCRIPTION
### 修改内容

#### main.py
- 模块顶部启用 `faulthandler`，并把崩溃堆栈写入 `logs/ok-ww_fault.log`：
  - `faulthandler.enable(file=_fault_file)`：记录所有致命错误（如访问违规）时的 Python 栈。
  - `faulthandler.register(signal.SIGSEGV, file=_fault_file)`：原生段错误时输出当前线程的 Python 调用栈。
- 原因：打包后的应用以 `pythonw.exe` 运行，没有控制台；此前原生崩溃（如图形后端访问违规）
  进程直接静默退出，无法定位。启用后崩溃现场会留在 `logs/ok-ww_fault.log`，便于排查。
- 兜底：若日志目录不可写，回退到 `faulthandler.enable()`（默认 stderr）。

#### main_debug.py
- 与 main.py 相同，为调试入口也启用 faulthandler。

### 备注
- 框架层修复（GUI 卡死线程风暴、单实例互斥锁、GUI 看门狗、悬浮窗等）已提交到 ok-script 仓库：
  https://github.com/ok-oldking/ok-script/pull/88
