### PR TITLE
fix: 开始挑战点击增加 click_after_delay=0.5, 避免进队界面吞点发呆卡死

### DIFF
--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -1113,7 +1113,7 @@ class BaseWWTask(BaseTask):
         )
 
     def click_team_challenge(self):
-        self.wait_click_feature('team_start_challenge', raise_if_not_found=True, after_sleep=1)
+        self.wait_click_feature('team_start_challenge', raise_if_not_found=True, click_after_delay=0.5, after_sleep=1)
         self.wait_click_skip_dialog_confirm()
 
     def wait_click_travel(self):


### PR DESCRIPTION
## 背景

无音区/一条龙梦魇进队后"发呆"——点完`开始挑战`后脚本静默等待, 多则 90+ 秒无动作(测试日志 2026-08-19: 无音区 09:24 点击后 96s 静默才进战斗; 梦魇 09:32 等待 120s 无果, 需手动停任务)。

## 根因

`click_team_challenge` 里 `wait_click_feature('team_start_challenge')` 采用签名默认 `click_after_delay=0`(一匹配就点击)。鸣潮 3.5.31/3.5.32 进队(队伍界面)瞬间按钮/命中区仍在滑入动画中, 这一下点击可能被游戏吞掉 → 队伍界面一直挂着 → 脚本唯一的进入判定 `in_team()`(底部角色名槽 OCR)静默轮询最长 120s → 表现为"进队后发呆"; 点击未生效也没有任何重试/核实。

对比例证: 同配置下 09:28/09:30 两次进战斗仅 ~7-8s(走的是同一条 `team_start_challenge` 点击), 说明按钮坐标与流程本身正确, 差异在点击瞬间的吞点窗口。

## 改动

`src/task/BaseWWTask.py` click_team_challenge:

```python
# 改前
self.wait_click_feature('team_start_challenge', raise_if_not_found=True, after_sleep=1)
# 改后
self.wait_click_feature('team_start_challenge', raise_if_not_found=True, click_after_delay=0.5, after_sleep=1)
```

点击前加 0.5s 缓冲, 显著降低被吞概率。与已有 `choose_level`/直接挑战流程中 `gray_button_challenge`/`gray_start_battle` 的 `click_after_delay=0.5` 用法一致。

覆盖入口(全部经 `click_team_challenge` 公共函数, 共 5 处): TacetTask/ NightmareNestTask/ FarmEchoTask/ ForgeryTask / SimulationTask。

不改全局默认 `click_after_delay`(ok/ 为通用框架), 仅本调用点加 0.5。

## 验证

- `py_compile` 通过
- 每次进队挑战多花 0.5s, 日常可忽略
- 本地测试目录已同改动实测

