### PR TITLE
fix(qingxiao): 修复大招前 h2 不开,增加 h2 释放保护与轮询保护 R 释放

### DIFF
--- a/src/char/Qingxiao.py
+++ b/src/char/Qingxiao.py
@@ -6,6 +6,8 @@ from src.char.BaseChar import BaseChar
 
 class Qingxiao(BaseChar):
     HEAVY_TIMEOUT = 2
+    # 图标连续"暗"满该时长才确认释放(去抖):瞬时模板漏检的假灭到不了这么长,不算数
+    HEAVY_CONFIRM = 0.25
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -19,21 +21,32 @@ class Qingxiao(BaseChar):
             return self.switch_next_char()
 
         start = time.time()
+        broke_on_h2 = False
         if self.must_cast_lib_this_turn:
             while self.time_elapsed_accounting_for_freeze(start) < 18:
                 self.cycle_start()
                 if heavy := self.handle_heavy():
-                    self.f_break()
                     if heavy == Labels.qingxiao_h2:
-                        self.click_liberation()
+                        # 第二次(强化)重击:图标已被 handle_heavy 确认灭(真释放)才回到这 → 开 R
+                        avail0 = self.liberation_available()
+                        if not avail0:
+                            # h2 多段命中的后半段会把 R 能量打满;等 R 图标亮(上限 1.5s)再开大
+                            self.task.wait_until(lambda: self.liberation_available(), time_out=1.5)
+                        lib_ok = self.click_liberation()
+                        broke_on_h2 = True
                         break
+                    self.f_break()
                 elif self.cast_enhanced_resonance():
                     pass
                 else:
                     self.click()
                 self.cycle_sleep()
-            self.handle_heavy()
+            if not broke_on_h2:
+                self.handle_heavy()
 
+        if broke_on_h2:
+            # R 未放出时(按钮没亮),强化重击落地动画还没结束就切会撞 not_in_team ERROR;等切人判定稳定再切
+            self.task.wait_until(lambda: self.task.in_team()[0], time_out=1.0)
         self.switch_next_char()
 
     def enhanced_resonance_available(self):
@@ -58,14 +71,26 @@ class Qingxiao(BaseChar):
             return False
 
         start = time.time()
+        dark_since = None
+        exited_confirm = False
         self.task.mouse_down()
         try:
-            while (
-                    self.heavy_available()
-                    and self.time_elapsed_accounting_for_freeze(start) < self.HEAVY_TIMEOUT
-            ):
+            # 去抖:图标连续暗满 HEAVY_CONFIRM 秒才算真释放(过滤瞬时模板漏检的假灭)。真蓄力时图标亮着。
+            while self.time_elapsed_accounting_for_freeze(start) < self.HEAVY_TIMEOUT:
+                now = time.time()
+                if self.heavy_available():
+                    dark_since = None
+                else:
+                    if dark_since is None:
+                        dark_since = now
+                    else:
+                        if now - dark_since >= self.HEAVY_CONFIRM:
+                            exited_confirm = True
+                            break
                 self.task.next_frame()
         finally:
             self.task.mouse_up()
         self.sleep(0.01)
-        return heavy.name
+        if exited_confirm:
+            return heavy.name
+        return False

--- a/src/char/Qingxiao.py
+++ b/src/char/Qingxiao.py
@@ -6,7 +6,7 @@ from src.char.BaseChar import BaseChar
 
 class Qingxiao(BaseChar):
     HEAVY_TIMEOUT = 2
-    # 图标连续"暗"满该时长才确认释放(去抖):瞬时模板漏检的假灭到不了这么长,不算数
+    # 图标连续"暗"满该时长才确认释放(去抖)
     HEAVY_CONFIRM = 0.25
 
     def __init__(self, *args, **kwargs):
@@ -75,7 +75,7 @@ class Qingxiao(BaseChar):
         exited_confirm = False
         self.task.mouse_down()
         try:
-            # 去抖:图标连续暗满 HEAVY_CONFIRM 秒才算真释放(过滤瞬时模板漏检的假灭)。真蓄力时图标亮着。
+            # 去抖:图标连续暗满 HEAVY_CONFIRM 秒才算真释放
             while self.time_elapsed_accounting_for_freeze(start) < self.HEAVY_TIMEOUT:
                 now = time.time()
                 if self.heavy_available():

--- a/src/char/Qingxiao.py
+++ b/src/char/Qingxiao.py
@@ -26,16 +26,15 @@ class Qingxiao(BaseChar):
             while self.time_elapsed_accounting_for_freeze(start) < 18:
                 self.cycle_start()
                 if heavy := self.handle_heavy():
+                    self.f_break()
                     if heavy == Labels.qingxiao_h2:
                         # 第二次(强化)重击:图标已被 handle_heavy 确认灭(真释放)才回到这 → 开 R
-                        avail0 = self.liberation_available()
-                        if not avail0:
+                        if self.task is not None and not self.liberation_available():
                             # h2 多段命中的后半段会把 R 能量打满;等 R 图标亮(上限 1.5s)再开大
                             self.task.wait_until(lambda: self.liberation_available(), time_out=1.5)
-                        lib_ok = self.click_liberation()
+                        self.click_liberation()
                         broke_on_h2 = True
                         break
-                    self.f_break()
                 elif self.cast_enhanced_resonance():
                     pass
                 else:
@@ -44,7 +43,7 @@ class Qingxiao(BaseChar):
             if not broke_on_h2:
                 self.handle_heavy()
 
-        if broke_on_h2:
+        if broke_on_h2 and self.task is not None:
             # R 未放出时(按钮没亮),强化重击落地动画还没结束就切会撞 not_in_team ERROR;等切人判定稳定再切
             self.task.wait_until(lambda: self.task.in_team()[0], time_out=1.0)
         self.switch_next_char()
@@ -75,19 +74,20 @@ class Qingxiao(BaseChar):
         exited_confirm = False
         self.task.mouse_down()
         try:
-            # 去抖:图标连续暗满 HEAVY_CONFIRM 秒才算真释放
+            # 去抖:图标暗掉后睡确认窗,复核仍暗才算真释放
             while self.time_elapsed_accounting_for_freeze(start) < self.HEAVY_TIMEOUT:
-                now = time.time()
                 if self.heavy_available():
                     dark_since = None
+                    self.task.next_frame()
                 else:
                     if dark_since is None:
-                        dark_since = now
-                    else:
-                        if now - dark_since >= self.HEAVY_CONFIRM:
-                            exited_confirm = True
-                            break
-                self.task.next_frame()
+                        dark_since = time.time()
+                    self.sleep(self.HEAVY_CONFIRM)
+                    self.task.next_frame()
+                    if not self.heavy_available():
+                        exited_confirm = True
+                        break
+                    dark_since = None
         finally:
             self.task.mouse_up()
         self.sleep(0.01)

--- a/tests/TestChar.py
+++ b/tests/TestChar.py
@@ -1302,7 +1302,8 @@ class TestChar(TaskTestCase):
 
     def test_qingxiao_heavy_holds_until_both_indicators_disappear(self):
         class Task:
-            indicators = [Labels.qingxiao_h1, Labels.qingxiao_h2, None]
+            # 图标熄灭后,去抖确认窗还会再取一帧复核,故暗帧需要两帧
+            indicators = [Labels.qingxiao_h1, Labels.qingxiao_h2, None, None]
 
             def __init__(self):
                 self.frame = 0
@@ -1333,7 +1334,7 @@ class TestChar(TaskTestCase):
 
         self.assertTrue(qingxiao.handle_heavy())
         self.assertEqual(task.actions, ['mouse_down', 'mouse_up'])
-        self.assertEqual(task.frame, 2)
+        self.assertEqual(task.frame, 3)
 
     def test_qingxiao_is_registered_as_wind_main_dps(self):
         info = char_dict[Labels.char_qingxiao]


### PR DESCRIPTION
# PR 说明 / PR Description

## 修改内容 / Changes

1. 修复大招前不开 h2，增加 h2 释放保护 
原逻辑把图标瞬时模板漏检的"假灭"误判为已释放,h2 强化重击起手即被打断/跳过,导致大招前强化重击打不出来。现改为:图标连续熄灭满 HEAVY_CONFIRM(0.25s)去抖确认后才算真释放;未确认则留在循环重试,确保 h2 在大招前真实打出。

2. 轮询保护 R 释放 
h2 松手后轮询等待 R 图标亮起(上限 1.5s)——h2 多段命中的能量到账后 R 才真正可用,等亮后再开大;R 未放出时,切人前先等切人判定稳定,避免 not_in_team 异常中断战斗。


## 修改类型 / Type of Change

- [x] Bug 修复 / Bug fix

## 新功能或大改确认 / New Feature or Major Change Confirmation

- [x] 不适用,本 PR 不是新功能或大改 / Not applicable; this PR is not a new feature or major change

## 测试 / Testing

- 实机战斗验证(多轮日志):h2 均确认释放;R 未充能时不再按出残留 h2;not_in_team 错误消除;三份运行副本同步、py_compile 通过。
- Validated in live fights (multiple runs): h2 release confirmed every rotation; no spurious h2 press when R is uncharged; "not in team" error gone; all three run copies synced, py_compile passes.

## 截图或录屏 / Screenshots or Recordings

- 不适用 / N/A

## 检查清单 / Checklist

- [x] 我已阅读 [CONTRIBUTING.md](https://github.com/ok-oldking/ok-wuthering-waves/blob/master/CONTRIBUTING.md) / I have read CONTRIBUTING.md
- [x] 我已阅读 README 中的免责声明 / I have read the disclaimer in the README
- [x] 我已尽量保持 PR 范围清晰,没有混入无关修改 / I have kept this PR focused and avoided unrelated changes
- [x] 我已说明测试结果或无法测试的原因 / I have described the test results or why testing was not possible
- [x] 我没有提交日志、缓存、临时文件或个人配置 / I have not committed logs, caches, temporary files, or personal settings