### PR TITLE
fix: make echo reconstruction clicks reliable

### DIFF
--- a/src/task/ChangeEchoTask.py
+++ b/src/task/ChangeEchoTask.py
@@ -41,6 +41,10 @@ class ChangeEchoTask(BaseWWTask, FindFeature):
     def is_0_level(self):
         return self.ocr(0.66, 0.48, 0.77, 0.56, match=re.compile('声骸技能'))
 
+    def click_with_mouse_move(self, x, y=-1, after_sleep=0, name=None):
+        """Hover before clicking controls that ignore a bare PostMessage click."""
+        self.click(x, y, move=True, name=name, after_sleep=after_sleep)
+
     def run(self):
         self.info_set('成功声骸数量', 0)
         while True:
@@ -76,15 +80,23 @@ class ChangeEchoTask(BaseWWTask, FindFeature):
                 raise Exception('找不到当前主属性!')
             if target_main in current_main[0].name:
                 raise Exception('目标属性和当前属性相同, 请修改声骸过滤条件!')
-            self.click(0.04, 0.41)
+            self.click_with_mouse_move(0.04, 0.41, name='数据重构入口', after_sleep=0.8)
             self.wait_ocr(match='主音属性', raise_if_not_found=True)
             self.sleep(0.8)
-            self.click(0.52, 0.71)
+            self.click_with_mouse_move(0.52, 0.71, name='主音属性选择', after_sleep=0.8)
             target = self.wait_ocr(match=re.compile(target_main), raise_if_not_found=True)
-            self.sleep(0.1)
-            self.click(target, after_sleep=0.5)
-            self.wait_click_ocr(match='确认', after_sleep=2)
-            self.wait_click_ocr(0.37, 0.82, 0.64, 0.99, match='数据重构', after_sleep=0.5, raise_if_not_found=True)
+            self.sleep(0.5)
+            self.click_with_mouse_move(target, after_sleep=0.8)
+            confirm = self.wait_ocr(match='确认', raise_if_not_found=True)
+            self.click_with_mouse_move(confirm, after_sleep=2)
+            reconstruct = self.wait_ocr(
+                0.37, 0.82, 0.64, 0.99,
+                match='数据重构',
+                time_out=5,
+            )
+            if not reconstruct:
+                raise Exception(f'未能选中目标属性「{target_main}」，请检查数据重构界面是否已更新!')
+            self.click_with_mouse_move(reconstruct, after_sleep=0.5)
             self.wait_ocr(match='获得声骸', raise_if_not_found=True)
             self.esc()
             self.info_incr('成功声骸数量')

--- a/tests/TestChangeEchoTask.py
+++ b/tests/TestChangeEchoTask.py
@@ -1,0 +1,38 @@
+import unittest
+from unittest.mock import Mock
+
+from src.task.ChangeEchoTask import ChangeEchoTask
+
+
+class TestChangeEchoTask(unittest.TestCase):
+
+    def test_control_click_moves_mouse_before_pressing(self):
+        task = ChangeEchoTask.__new__(ChangeEchoTask)
+        task.click = Mock()
+        boxes = [object()]
+
+        task.click_with_mouse_move(boxes, after_sleep=0.8)
+
+        task.click.assert_called_once_with(
+            boxes, -1, move=True, name=None, after_sleep=0.8
+        )
+
+    def test_relative_control_click_keeps_coordinates_and_log_name(self):
+        task = ChangeEchoTask.__new__(ChangeEchoTask)
+        task.click = Mock()
+
+        task.click_with_mouse_move(
+            0.04, 0.41, name='数据重构入口', after_sleep=0.8
+        )
+
+        task.click.assert_called_once_with(
+            0.04,
+            0.41,
+            move=True,
+            name='数据重构入口',
+            after_sleep=0.8,
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# PR 说明 / PR Description

## 修改内容 / Changes

修复“批量修改声骸主属性”任务中，日志显示已经点击，但游戏界面偶发没有响应的问题。

具体修改：

- 新增 `click_with_mouse_move()`，在点击前强制发送鼠标移动事件。
- 数据重构入口、主音属性选择、目标属性、确认和数据重构按钮统一使用该点击方式。
- 适当增加界面切换后的等待时间。
- 进入二次确认失败时，提供更明确的错误信息。
- 添加单元测试，确保关键控件点击始终传入 `move=True`。

## 修改原因 / Why

项目在 Windows 下使用 `PostMessage` 向游戏发送后台点击。

原来的部分点击使用 `move=False`，只发送鼠标按下和抬起消息，不会先发送 `WM_MOUSEMOVE`。数据重构界面的部分控件可能因此没有更新鼠标悬停及命中状态，表现为：

- 日志记录了正确的点击坐标；
- 相同位置用真实鼠标可以正常点击；
- 自动点击偶发没有任何界面响应。

修复后会先把鼠标移动到目标控件，再发送按下和抬起消息，模拟完整的正常鼠标点击流程。

本修改只作用于 `ChangeEchoTask`，没有修改 `ok-script` 的全局点击行为，避免影响其他任务。

## 修改类型 / Type of Change

- [x] Bug 修复 / Bug fix
- [x] 小型优化或兼容性修复 / Small improvement or compatibility fix
- [ ] 文档或翻译 / Documentation or translation
- [ ] 新功能 / New feature
- [ ] 大幅修改现有功能 / Major modification of existing behavior
- [ ] 重构或架构调整 / Refactor or architecture change

## 新功能或大改确认 / New Feature or Major Change Confirmation

- [x] 不适用，本 PR 不是新功能或大改 / Not applicable; this PR is not a new feature or major change
- [ ] 已联系作者或已在社区讨论 / I have contacted the author or discussed this in the community

## 测试 / Testing

测试环境：

- Windows
- 1600 × 900
- 简体中文游戏语言
- `PostMessage` 交互方式
- Python 3.12

验证结果：

- 新增的 2 个单元测试通过。
- 修改后的文件通过 `py_compile` 语法检查。
- 游戏内连续完成 4 轮声骸主属性修改。
- 数据重构入口、属性选择、确认和二次确认均正常响应。
- 未再出现点击日志存在但界面未响应的问题。

## 截图或录屏 / Screenshots or Recordings

修复前日志显示点击坐标正确，但属性选择和数据重构入口偶发不响应。

修复后连续 4 轮完整执行成功。

## 检查清单 / Checklist

- [x] 我已阅读 CONTRIBUTING.md / I have read CONTRIBUTING.md
- [x] 我已阅读 README 中的免责声明 / I have read the disclaimer in the README
- [x] 我已尽量保持 PR 范围清晰，没有混入无关修改
- [x] 我已说明测试结果
- [x] 我没有提交日志、缓存、临时文件或个人配置