### PR TITLE
fix(login): auto-click the connect button on 3.6.x login screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ python main.py
 python main_debug.py
 ```
 
+> **注意（Windows）**: 如果游戏客户端以管理员权限运行（例如通过 WeGame 启动），ok-ww 也必须以管理员权限运行（右键 `pythonw.exe` 的快捷方式 → "以管理员身份运行"，或在管理员 PowerShell 中运行命令）。否则 Windows 会拒绝向游戏窗口发送按键/点击（`PostMessage` 错误码 5），自动登录等所有交互都不会生效。
+
 ### 命令行参数
 
 您可以通过命令行参数实现自动化启动。

--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -766,6 +766,13 @@ class BaseWWTask(BaseTask):
                         self.click(login, after_sleep=1)
                         self.log_info('点击登录按钮!')
                 return False
+            if connect := self.find_boxes(texts,
+                                          boundary=self.box_of_screen(0.2, 0.75, 0.8, 0.98),
+                                          match=re.compile(r'点击连接|Click to Connect', re.IGNORECASE)):
+                # 3.6.x 登录/连接界面:点击"点击连接"后直接进入游戏主界面
+                self.click(connect[0], after_sleep=2)
+                self.log_info('点击连接按钮!')
+                return False
             if agree := self.find_boxes(texts, boundary=login_box, match="同意"):
                 self.log_debug(f'found agree {agree}')
                 if self.find_boxes(texts, boundary=login_box, match=re.compile("隐私")):

--- a/tests/TestWaitLogin.py
+++ b/tests/TestWaitLogin.py
@@ -1,3 +1,4 @@
+import re
 import unittest
 
 from src.task.BaseWWTask import BaseWWTask, LOGIN_CLICK_SETTLE_TIME, LOGIN_TEXTS
@@ -46,10 +47,15 @@ class FakeLoginTask:
                     if 'log' in b.name.lower() or '登录' in b.name or '登入' in b.name] or None
         if match == "+86":
             return [b for b in texts if '+86' in b.name] or None
+        if isinstance(match, re.Pattern):
+            # 与真实 ok.find_boxes 一致:re.Pattern 做 re.search 子串匹配
+            return [b for b in texts if re.search(match, b.name)] or None
         return None
 
     def click(self, target, after_sleep=0):
-        self.clicked.append([b.name for b in target])
+        # 与真实 ok.BaseTask.click 兼容:接受单个 Box 或 Box 列表
+        targets = target if isinstance(target, list) else [target]
+        self.clicked.append([b.name for b in targets])
 
     def sleep(self, timeout):
         self.slept.append(timeout)
@@ -104,6 +110,16 @@ class TestWaitLogin(unittest.TestCase):
 
         self.assertFalse(result)
         self.assertEqual(task.clicked, [])
+
+    def test_connect_button_is_clicked(self):
+        # 3.6.x 连接界面按钮:regex 子串匹配,OCR 文本含多余字符也能命中;
+        # 多匹配(如右下角重试图标)时排序后取第一个(主按钮)
+        task = FakeLoginTask(frames=[[TextBox('点击连接'), TextBox('点击连接 :: 重试')]])
+
+        result = BaseWWTask.wait_login(task)
+
+        self.assertFalse(result)
+        self.assertEqual(task.clicked, [['点击连接']])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 修改内容 / Changes

- `src/task/BaseWWTask.py`:`wait_login()` 新增对登录/连接界面底部"点击连接 / Click to Connect"按钮的识别与点击(3.6.x 界面,该文本不在原有 `LOGIN_TEXTS` 处理范围内,导致自动登录静默无动作)。
- `tests/TestWaitLogin.py`:测试桩 `FakeLoginTask.find_boxes` 对齐真实 `ok.find_boxes` 语义(支持 `re.Pattern` 匹配),新增 `test_connect_button_is_clicked` 用例(覆盖 OCR 含噪文本及多匹配时取主按钮)。
- `README.md`:源码运行小节补充说明 —— 游戏以管理员运行时(如 WeGame),ok-ww 也必须以管理员运行,否则 Windows 拒绝 `PostMessage`(错误码 5),自动登录点击会被系统拦截。

## 修改类型 / Type of Change

- [x] 小型优化或兼容性修复 / Small improvement or compatibility fix
- [x] 文档或翻译 / Documentation or translation

## 新功能或大改确认 / New Feature or Major Change Confirmation

- [x] 不适用,本 PR 不是新功能或大改 / Not applicable; this PR is not a new feature or major change

## 测试 / Testing

- `.\run_tests.ps1`:全部 31 个测试文件通过(含新增用例)。
- 实机验证(3.6.x 客户端,1920x1080):游戏停在登录界面时自动登录触发,日志确认:

```
AutoLoginTask: left_click 点击连接 (961, 1009) after_sleep 2
AutoLoginTask: 点击连接按钮!
AutoCombatTask: loaded chars success Hiyuki / Chisa / Linnai   ← 已进入游戏主界面
```

说明:未加 #1356 式的点击前 settle 复核,原因:该按钮在连接界面为常驻必点项(点击后立即进入主界面,下一次轮询即命中 `in_team_and_world` 分支),与可能被游戏自动登录跳过的"登录"按钮不同,重复点击风险低。

## 截图或录屏 / Screenshots or Recordings

无录屏;上方日志节选即用户可见行为的验证记录。附带说明:排查中还确认了"游戏以管理员运行时 ok-ww 需以管理员运行"这一已知限制并给出规避指引(README 已同步,为人工操作说明,代码未做自动化处理),未改动其他行为。

## 检查清单 / Checklist

- [x] 我已阅读 CONTRIBUTING.md / I have read CONTRIBUTING.md
- [x] 我已阅读 README 中的免责声明 / I have read the disclaimer in the README
- [x] 我已尽量保持 PR 范围清晰,没有混入无关修改 / I have kept this PR focused and avoided unrelated changes
- [x] 我已说明测试结果或无法测试的原因 / I have described the test results or why testing was not possible
- [x] 我没有提交日志、缓存、临时文件或个人配置 / I have not committed logs, caches, temporary files, or personal settings
