### PR TITLE
fix(domain): 副本未通关时不再中断整个每日任务

### DIFF
--- a/src/task/DomainTask.py
+++ b/src/task/DomainTask.py
@@ -1,7 +1,7 @@
 import re
 
 
-from ok import Logger
+from ok import Logger, WaitFailedException
 from src.task.BaseCombatTask import BaseCombatTask, NotInCombatException, CharDeadException
 from src.task.WWOneTimeTask import WWOneTimeTask
 
@@ -89,8 +89,12 @@ class DomainTask(WWOneTimeTask, BaseCombatTask):
                 self.sleep(3)
                 self.walk_to_treasure()
                 self.pick_f(handle_claim=False)
-            except (NotInCombatException, CharDeadException):
-                self.log_info('farm_in_domain: death recovered, exiting domain')
+            except (NotInCombatException, CharDeadException, WaitFailedException):
+                # WaitFailedException: 副本没打通（限时结束 / 敌人没清完）就不会掉宝箱，
+                # walk_to_treasure 找不到目标会抛它。和死亡一样当成“这一局没打成”，
+                # 交给 farm_domain_with_recovery_loop 重进；否则它会一路抛到
+                # DailyTask.run，把后面的领奖和附加任务全带走。
+                self.log_info('farm_in_domain: attempt failed, exiting domain')
                 self.make_sure_in_world()
                 return False, must_use
             can_continue, used = self.use_stamina(once=self.stamina_once, must_use=must_use)

--- a/tests/TestDomainRecoveryLoop.py
+++ b/tests/TestDomainRecoveryLoop.py
@@ -14,6 +14,10 @@ class TestDomainRecoveryLoop(unittest.TestCase):
             node for node in class_node.body
             if isinstance(node, ast.FunctionDef) and node.name == "farm_domain_with_recovery_loop"
         )
+        self.farm_in_domain_node = next(
+            node for node in class_node.body
+            if isinstance(node, ast.FunctionDef) and node.name == "farm_in_domain"
+        )
 
     def test_method_has_retry_parameter_with_default(self):
         args = self.method_node.args.args
@@ -72,6 +76,67 @@ class TestDomainRecoveryLoop(unittest.TestCase):
             for node in ast.walk(self.method_node)
         )
         self.assertTrue(has_unpack)
+
+
+    def _farm_in_domain_handlers(self):
+        return [
+            node for node in ast.walk(self.farm_in_domain_node)
+            if isinstance(node, ast.ExceptHandler)
+        ]
+
+    def test_failed_attempt_is_recoverable_instead_of_aborting_the_task(self):
+        """副本没打通不该把整个 DailyTask 带走。
+
+        打不通时不会掉宝箱，walk_to_treasure 会抛 WaitFailedException。
+        它必须和死亡一样被当成“这一局没打成”，交给 farm_domain_with_recovery_loop
+        重试；否则它会一路穿到 DailyTask.run，后面的领奖和附加任务全被跳过。
+        """
+        caught = set()
+        for handler in self._farm_in_domain_handlers():
+            if handler.type is None:
+                continue
+            names = handler.type.elts if isinstance(handler.type, ast.Tuple) else [handler.type]
+            caught.update(n.id for n in names if isinstance(n, ast.Name))
+        self.assertIn("WaitFailedException", caught)
+        self.assertIn("NotInCombatException", caught)
+        self.assertIn("CharDeadException", caught)
+
+    def test_walk_to_treasure_is_inside_the_guarded_block(self):
+        """守卫要真的盖住抛异常的那一句，不然加了也白加。"""
+        guarded = any(
+            any(
+                isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Attribute)
+                and call.func.attr == "walk_to_treasure"
+                for stmt in node.body
+                for call in ast.walk(stmt)
+            )
+            and any(
+                isinstance(handler.type, ast.Tuple)
+                and any(
+                    isinstance(n, ast.Name) and n.id == "WaitFailedException"
+                    for n in handler.type.elts
+                )
+                for handler in node.handlers
+            )
+            for node in ast.walk(self.farm_in_domain_node)
+            if isinstance(node, ast.Try)
+        )
+        self.assertTrue(guarded)
+
+    def test_failed_attempt_returns_not_finished_so_the_loop_retries(self):
+        """返回 False 才会进入外层重试；返回 True 会被当成正常结束。"""
+        returns = [
+            node for handler in self._farm_in_domain_handlers()
+            for node in ast.walk(handler)
+            if isinstance(node, ast.Return)
+        ]
+        self.assertTrue(returns)
+        for node in returns:
+            self.assertIsInstance(node.value, ast.Tuple)
+            first = node.value.elts[0]
+            self.assertIsInstance(first, ast.Constant)
+            self.assertIs(first.value, False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 问题

副本未通关（限时结束或敌人未清完）时不会生成宝箱，`walk_to_treasure()`
找不到目标，`wait_until(raise_if_not_found=True)` 抛出 `WaitFailedException`。

该异常不在 `farm_in_domain` 的 `except` 范围内，会沿
`farm_domain_with_recovery_loop` → `farm_forgery` → `DailyTask.run`
向上传播，中断整个每日任务：凝素领域之后的领取日常、邮件、战令与附加任务全部跳过。

同时，紧邻的恢复机制对这一失败模式完全失效：`farm_domain_with_recovery_loop`
本身具备从 F2 重新进入、并在 `max_recovery_retries` 用尽后正常停止的能力，
但只能经由 `return False` 进入，异常将其直接绕过。

## 修改内容

将「未生成宝箱」与「角色死亡」同等处理：本次尝试未成功，返回 `False`，
交由已有的恢复循环处理。

- `src/task/DomainTask.py`：`except` 子句增加 `WaitFailedException`，并补充对应 import。
- `tests/TestDomainRecoveryLoop.py`：新增 3 个用例。