### PR TITLE
fix(nest): 残象聚落支持续刷未打满的点位，失败不再无限重试，并新增只刷指定点位

### DIFF
--- a/src/task/NightmareNestTask.py
+++ b/src/task/NightmareNestTask.py
@@ -15,6 +15,9 @@ CONFIRM_FEATURES = ['confirm_btn_hcenter_vcenter', 'confirm_btn_highlight_hcente
 class NestTarget:
     box: object
     cache_key: str
+    # 已击败数。允许续刷未清空的点位之后，同一个 cache_key 会反复出现，
+    # 靠它才能分清「打出了进展」和「原地空转」。
+    progress: str = ""
 
 
 class NightmareNestTask(WWOneTimeTask, BaseCombatTask):
@@ -54,7 +57,7 @@ class NightmareNestTask(WWOneTimeTask, BaseCombatTask):
     def _next_nest_with_progress(self):
         """取下一个巢穴；同一个巢穴打完计数没动就不再重试。
 
-        `find_nest()` 只挑「已击败 0/N」的巢穴，所以只要一局打完计数没涨，
+        `find_nest()` 会一直挑没打满的巢穴，所以一局打完计数没涨的话，
         下一轮它还会被选中——形成无限循环。队伍打不过挑战时最明显：
         游戏弹「挑战失败」（提示提升角色/武器/声骸/技能等级），
         而这个界面 OK-WW 并不认识，于是每两分钟原地重进一次，永不放弃。
@@ -64,14 +67,16 @@ class NightmareNestTask(WWOneTimeTask, BaseCombatTask):
         还是传送点不对，都一视同仁地跳过，把时间让给下一个巢穴。
         """
         while nest := self.get_nest_to_go():
-            key = nest.cache_key if isinstance(nest, NestTarget) else None
-            if key is None:
+            if not isinstance(nest, NestTarget):
                 return nest                 # 认不出身份的目标，交给原有流程
-            if key in self._attempted_nests:
-                self._unreachable_nests.add(key)
-                self.log_info(f'nightmare nest: no progress after an attempt, skip: {key}')
+            # 键里带上进度：打出了进展就是新的一次机会，原地不动才算白打。
+            stamp = f'{nest.cache_key}@{nest.progress}'
+            if stamp in self._attempted_nests:
+                self._unreachable_nests.add(nest.cache_key)
+                self.log_info('nightmare nest: no progress after an attempt, '
+                              f'skip: {nest.cache_key} (still {nest.progress})')
                 continue                    # 下一轮 find_nest 会跳过它
-            self._attempted_nests.add(key)
+            self._attempted_nests.add(stamp)
             return nest
 
     def run_capture_mode(self):
@@ -240,7 +245,12 @@ class NightmareNestTask(WWOneTimeTask, BaseCombatTask):
             for match in re.finditer(self.count_re, count_box.name):
                 numerator = match.group(1)
                 denominator = match.group(2)
-                if numerator != denominator and denominator in ['24', '36', '48', '41'] and numerator == '0':
+                # 只要没打满就能接着打，不要求「一只都没打过」。
+                # 原来这里还有一个 `numerator == '0'`：一个点位只要刷过一只，
+                # 就被永久跳过，剩下的 40 多只再也不会去打。2026-08-26 实测，
+                # 四个残象聚落刷到 10/41、6/48、48/48、24/24 之后，
+                # 任务每轮都报「没有可刷的巢穴」直接收工——两个没满的都被这行挡掉了。
+                if numerator != denominator and denominator in ['24', '36', '48', '41']:
                     cache_key = self._make_nest_cache_key(count_box, denominator)
                     if cache_key in self._unreachable_nests:
                         self.log_info(f'skip cached unreachable nightmare nest: {cache_key}')
@@ -250,7 +260,7 @@ class NightmareNestTask(WWOneTimeTask, BaseCombatTask):
                     count_box.y -= count_box.height * 0.9
                     count_box.height = 1
                     count_box.width = 1
-                    return NestTarget(count_box, cache_key)
+                    return NestTarget(count_box, cache_key, numerator)
 
     def _make_nest_cache_key(self, count_box, denominator):
         action_name = self.queues[0].__name__ if self.queues else 'unknown'

--- a/src/task/NightmareNestTask.py
+++ b/src/task/NightmareNestTask.py
@@ -32,6 +32,7 @@ class NightmareNestTask(WWOneTimeTask, BaseCombatTask):
         self._capture_success = False
         self._capture_mode = False
         self._unreachable_nests = set()
+        self._attempted_nests = set()
         self._nest_tab_of_current_nest = 'go_nest'
         self.default_config.update({'Which to Farm': ['Nightmare Purification', 'Tacet Discord Nest']})
         self.config_type['Which to Farm'] = {'type': "multi_selection",
@@ -41,23 +42,48 @@ class NightmareNestTask(WWOneTimeTask, BaseCombatTask):
         self._capture_mode = False
         self._capture_success = False
         self._unreachable_nests.clear()
+        self._attempted_nests.clear()
         WWOneTimeTask.run(self)
         self.ensure_main(time_out=30)
         self._init_queue()
         self.log_info('opened gray_book_boss')
-        while nest := self.get_nest_to_go():
+        while nest := self._next_nest_with_progress():
             self.combat_nest(nest)
         self.ensure_main(time_out=30)
+
+    def _next_nest_with_progress(self):
+        """取下一个巢穴；同一个巢穴打完计数没动就不再重试。
+
+        `find_nest()` 只挑「已击败 0/N」的巢穴，所以只要一局打完计数没涨，
+        下一轮它还会被选中——形成无限循环。队伍打不过挑战时最明显：
+        游戏弹「挑战失败」（提示提升角色/武器/声骸/技能等级），
+        而这个界面 OK-WW 并不认识，于是每两分钟原地重进一次，永不放弃。
+
+        这里不去识别失败界面（多一个模板就多一处会随版本失效的地方），
+        而是用「打完一局计数没变」这个**结果**判定：无论打不过、没刷新、
+        还是传送点不对，都一视同仁地跳过，把时间让给下一个巢穴。
+        """
+        while nest := self.get_nest_to_go():
+            key = nest.cache_key if isinstance(nest, NestTarget) else None
+            if key is None:
+                return nest                 # 认不出身份的目标，交给原有流程
+            if key in self._attempted_nests:
+                self._unreachable_nests.add(key)
+                self.log_info(f'nightmare nest: no progress after an attempt, skip: {key}')
+                continue                    # 下一轮 find_nest 会跳过它
+            self._attempted_nests.add(key)
+            return nest
 
     def run_capture_mode(self):
         self._capture_mode = True
         self._capture_success = False
         self._unreachable_nests.clear()
+        self._attempted_nests.clear()
         WWOneTimeTask.run(self)
         self.ensure_main(time_out=30)
         self._init_queue()
         self.log_info('opened gray_book_boss')
-        while nest := self.get_nest_to_go():
+        while nest := self._next_nest_with_progress():
             self.combat_nest(nest)
             if self._capture_success:
                 break

--- a/src/task/NightmareNestTask.py
+++ b/src/task/NightmareNestTask.py
@@ -7,6 +7,21 @@ from src.task.BaseCombatTask import BaseCombatTask, CharRevivedException
 from src.task.WWOneTimeTask import WWOneTimeTask
 
 logger = Logger.get_logger(__name__)
+# 只刷指定点位。上游没有这个能力：find_nest 扫到哪个算哪个，
+# 想单独补某一个没打满的点位做不到（见 ok-oldking/ok-wuthering-waves#1622）。
+ONLY_NESTS = 'Only Farm These Nests'
+# 等点位列表渲染出来的秒数上限。够长能盖住加载慢，
+# 又不至于在列表真的空时把任务拖死。
+NEST_LIST_TIMEOUT = 15
+# 计数框允许比名字框低几个行高（同一张卡片内）。
+# 2026-08-27 在游戏里实测的坐标：
+#     落渊南丘残象聚落  y=300 h=35  → 行中心 317.5
+#     已击败残象：0/41  y=373 h=30  → 行中心 388.0     差 70.5px ≈ 2.35 行高
+#     下一个点位 盲望之塌 y=523              距南丘名字 148px ≈ 4.9 行高
+# 所以 4 行高（120px）既盖得住 2.35，又够不到 4.9，不会串到下一个点位。
+# 原来写死 1 行高，永远配不上——名字和计数根本不在同一行。
+NEST_ROW_SPAN = 4
+
 TRAVEL_FEATURES = ['fast_travel_custom', 'gray_teleport', 'remove_custom']
 CONFIRM_FEATURES = ['confirm_btn_hcenter_vcenter', 'confirm_btn_highlight_hcenter_vcenter']
 
@@ -37,9 +52,13 @@ class NightmareNestTask(WWOneTimeTask, BaseCombatTask):
         self._unreachable_nests = set()
         self._attempted_nests = set()
         self._nest_tab_of_current_nest = 'go_nest'
-        self.default_config.update({'Which to Farm': ['Nightmare Purification', 'Tacet Discord Nest']})
+        self.default_config.update({'Which to Farm': ['Nightmare Purification', 'Tacet Discord Nest'],
+                                    ONLY_NESTS: ''})
         self.config_type['Which to Farm'] = {'type': "multi_selection",
                                              'options': ['Nightmare Purification', 'Tacet Discord Nest']}
+        self.config_description[ONLY_NESTS] = (
+            '只刷指定的点位，填名字里认得出的一段即可，多个用逗号隔开，'
+            '例如「落渊南丘」。留空＝按原来的行为刷全部。')
 
     def run(self):
         self._capture_mode = False
@@ -239,9 +258,64 @@ class NightmareNestTask(WWOneTimeTask, BaseCombatTask):
     def go_nest(self):
         self.open_boss_book('canxiang')
 
+    def _wanted_nest_rows(self):
+        """配置了「只刷指定点位」时，那些点位各自在第几行（返回行中心的 y）。
+
+        名字和计数属于同一张卡片，但**不在同一行**——实测计数在名字下方
+        两行多（见 NEST_ROW_SPAN 的注释）。所以先按名字定位到行，
+        再在下方 NEST_ROW_SPAN 个行高之内去认它的计数框。
+        返回 None 表示没配置，照旧刷全部。
+        """
+        raw = (self.config.get(ONLY_NESTS) or '').strip()
+        if not raw:
+            return None
+        names = [n.strip() for n in re.split(r'[,，]', raw) if n.strip()]
+        # 点进列表之后它还要渲染一会儿。2026-08-27 实测：点击后才 2 秒就 OCR，
+        # 一个名字都读不到，于是判定「找不到指定点位」→ find_nest 直接返回 None
+        # → 残像聚落整段跳过，那天一次都没刷。所以先等列表真的出来。
+        # 「出来了」的判据是能读到任意一个「x/y」计数，不是等固定秒数。
+        for _ in range(NEST_LIST_TIMEOUT):
+            if self.ocr(0.35, 0.13, 1, 0.96, match=self.count_re):
+                break
+            self.sleep(1)
+        # 用**包含**匹配，不能用 ocr(match=...)：那个是精确相等。
+        # 2026-08-27 实测，OCR 读出来的是「落渊南丘残象聚落」，
+        # 而配置里写的是「落渊南丘」——精确匹配一个都对不上，
+        # 于是判成「列表里没有这个点位」，整段跳过，那天一次没刷。
+        boxes = self.ocr(0.35, 0.13, 1, 0.96)
+        rows = []
+        for name in names:
+            for box in boxes:
+                if name in (box.name or ''):
+                    rows.append(box.y + box.height / 2)
+        if not rows:
+            # 这不是「打满了」，是「配的名字根本不在列表里」，两者后果一样
+            # （什么都不刷）但原因完全不同，必须让人看见，不能只写进日志。
+            seen = [b.name for b in boxes]
+            self.log_error('nightmare nest: 列表里没找到指定的点位 '
+                           f'{names}；实际读到的是 {seen}', notify=True)
+        return rows
+
     def find_nest(self):
+        wanted_rows = self._wanted_nest_rows()
+        if wanted_rows is not None and not wanted_rows:
+            return None                     # 指定了，但一个都没在列表里 → 什么都别刷
+        hit_wanted = False
         counts = self.ocr(0.35, 0.13, 1, 0.96, match=self.count_re)
         for count_box in counts:
+            if wanted_rows is not None:
+                row = count_box.y + count_box.height / 2
+                # 名字和计数属于同一张卡片，但不一定在同一行——计数常在
+                # 名字下面一两行。所以只认「计数在名字下方 NEST_ROW_SPAN
+                # 个行高以内」，既能跨行，又不会串到下一个点位上去。
+                # 具体数值由上面那条几何日志量出来，不是拍脑袋。
+                span = count_box.height * NEST_ROW_SPAN
+                if not any(-count_box.height <= row - w <= span
+                           for w in wanted_rows):
+                    self.log_debug(f'nightmare nest: 计数 {count_box.name} '
+                                   f'(y={row}) 不属于任何指定点位 {wanted_rows}')
+                    continue
+                hit_wanted = True
             for match in re.finditer(self.count_re, count_box.name):
                 numerator = match.group(1)
                 denominator = match.group(2)
@@ -261,6 +335,8 @@ class NightmareNestTask(WWOneTimeTask, BaseCombatTask):
                     count_box.height = 1
                     count_box.width = 1
                     return NestTarget(count_box, cache_key, numerator)
+        if wanted_rows is not None and hit_wanted:
+            self.log_info('nightmare nest: 指定点位都已打满，跳过')
 
     def _make_nest_cache_key(self, count_box, denominator):
         action_name = self.queues[0].__name__ if self.queues else 'unknown'

--- a/tests/TestNightmareNestTask.py
+++ b/tests/TestNightmareNestTask.py
@@ -194,7 +194,7 @@ class TestNightmareNestTask(unittest.TestCase):
         find_nest 只挑「已击败 0/N」的巢穴，所以一局打完计数没涨的话，
         下一轮还会选中同一个，两分钟一轮地空转。
         """
-        stuck = NestTarget(FakeBox('0/36', y=300), 'go_nightmare:36:15')
+        stuck = NestTarget(FakeBox('0/36', y=300), 'go_nightmare:36:15', '0')
         task = self._task_with_nests([stuck])
 
         first = task._next_nest_with_progress()
@@ -206,8 +206,8 @@ class TestNightmareNestTask(unittest.TestCase):
         self.assertTrue(any('no progress' in log for log in task.logs))
 
     def test_skipping_a_stuck_nest_moves_on_to_the_next_one(self):
-        stuck = NestTarget(FakeBox('0/36', y=300), 'go_nightmare:36:15')
-        other = NestTarget(FakeBox('0/48', y=400), 'go_nest:48:20')
+        stuck = NestTarget(FakeBox('0/36', y=300), 'go_nightmare:36:15', '0')
+        other = NestTarget(FakeBox('0/48', y=400), 'go_nest:48:20', '0')
         task = self._task_with_nests([stuck, other])
 
         self.assertIs(task._next_nest_with_progress(), stuck)
@@ -217,14 +217,46 @@ class TestNightmareNestTask(unittest.TestCase):
 
     def test_a_nest_that_made_progress_is_not_blacklisted(self):
         """打完计数涨了，find_nest 就不会再吐同一个 key，正常继续。"""
-        first = NestTarget(FakeBox('0/36', y=300), 'go_nightmare:36:15')
-        after = NestTarget(FakeBox('0/48', y=400), 'go_nest:48:20')
+        first = NestTarget(FakeBox('0/36', y=300), 'go_nightmare:36:15', '0')
+        after = NestTarget(FakeBox('0/48', y=400), 'go_nest:48:20', '0')
         task = self._task_with_nests([first])
 
         self.assertIs(task._next_nest_with_progress(), first)
         task._pending[:] = [after]                       # 计数涨了，换成别的目标
         self.assertIs(task._next_nest_with_progress(), after)
         self.assertEqual(set(), task._unreachable_nests)
+
+    def test_partially_farmed_nest_is_still_offered(self):
+        """打过一部分的点位要能接着打——原来只认「已击败 0/N」。"""
+        task = NightmareNestTask.__new__(NightmareNestTask)
+        task.queues = [lambda: None]
+        task.count_re = re.compile(r"(\d{1,2})/(\d{1,2})")
+        task._unreachable_nests = set()
+        task.logs = []
+        task.log_info = lambda msg, **kwargs: task.logs.append(msg)
+        task.width_of_screen = lambda v: 1920 * v
+        task.height_of_screen = lambda v: 1080 * v
+        task.ocr = lambda *a, **k: [FakeBox('已击败残象：10/41', y=300)]
+
+        target = task.find_nest()
+        self.assertIsInstance(target, NestTarget)
+        self.assertEqual('10', target.progress)
+
+    def test_progress_gives_the_nest_another_attempt(self):
+        """计数涨了就不算白打，要再给一次机会；没涨才拉黑。"""
+        first = NestTarget(FakeBox('6/48', y=400), 'go_nest:48:20', '6')
+        task = self._task_with_nests([first])
+        self.assertIs(task._next_nest_with_progress(), first)
+
+        grown = NestTarget(FakeBox('12/48', y=400), 'go_nest:48:20', '12')
+        task._pending[:] = [grown]
+        self.assertIs(task._next_nest_with_progress(), grown)
+        self.assertEqual(set(), task._unreachable_nests)
+
+        same = NestTarget(FakeBox('12/48', y=400), 'go_nest:48:20', '12')
+        task._pending[:] = [same]
+        self.assertIsNone(task._next_nest_with_progress())
+        self.assertIn('go_nest:48:20', task._unreachable_nests)
 
     def test_attempt_memory_is_cleared_between_runs(self):
         """上一轮拉黑的巢穴，下一轮（比如第二天）要重新给机会。"""

--- a/tests/TestNightmareNestTask.py
+++ b/tests/TestNightmareNestTask.py
@@ -1,5 +1,6 @@
 import unittest
 import re
+from pathlib import Path
 
 from src.task.NightmareNestTask import NestTarget, NightmareNestTask
 
@@ -158,6 +159,86 @@ class TestNightmareNestTask(unittest.TestCase):
         shifted = task._make_nest_cache_key(FakeBox('0/36', y=202), '36')
 
         self.assertEqual(first, shifted)
+
+    def _task_with_nests(self, nests):
+        """把 get_nest_to_go 换成一个按 nests 顺序吐目标的桩。
+
+        真实的 get_nest_to_go 每轮都重新 OCR 一次列表，所以同一个没打动的
+        巢穴会被反复吐出来——这里照这个语义来。
+        """
+        task = NightmareNestTask.__new__(NightmareNestTask)
+        task._unreachable_nests = set()
+        task._attempted_nests = set()
+        task.logs = []
+        task.log_info = lambda msg, **kwargs: task.logs.append(msg)
+
+        pending = list(nests)
+
+        def get_nest_to_go():
+            while pending:
+                nest = pending[0]
+                key = nest.cache_key if isinstance(nest, NestTarget) else None
+                if key in task._unreachable_nests:
+                    pending.pop(0)
+                    continue
+                return nest
+            return None
+
+        task.get_nest_to_go = get_nest_to_go
+        task._pending = pending
+        return task
+
+    def test_nest_without_progress_is_skipped_instead_of_retried_forever(self):
+        """打不过的巢穴（游戏弹「挑战失败」）不能无限重进。
+
+        find_nest 只挑「已击败 0/N」的巢穴，所以一局打完计数没涨的话，
+        下一轮还会选中同一个，两分钟一轮地空转。
+        """
+        stuck = NestTarget(FakeBox('0/36', y=300), 'go_nightmare:36:15')
+        task = self._task_with_nests([stuck])
+
+        first = task._next_nest_with_progress()
+        self.assertIs(first, stuck)                      # 第一次照打
+
+        second = task._next_nest_with_progress()
+        self.assertIsNone(second)                        # 第二次不再给同一个
+        self.assertIn(stuck.cache_key, task._unreachable_nests)
+        self.assertTrue(any('no progress' in log for log in task.logs))
+
+    def test_skipping_a_stuck_nest_moves_on_to_the_next_one(self):
+        stuck = NestTarget(FakeBox('0/36', y=300), 'go_nightmare:36:15')
+        other = NestTarget(FakeBox('0/48', y=400), 'go_nest:48:20')
+        task = self._task_with_nests([stuck, other])
+
+        self.assertIs(task._next_nest_with_progress(), stuck)
+        # 第二轮：stuck 没进展 → 拉黑 → 换下一个，而不是原地卡住
+        self.assertIs(task._next_nest_with_progress(), other)
+        self.assertIn(stuck.cache_key, task._unreachable_nests)
+
+    def test_a_nest_that_made_progress_is_not_blacklisted(self):
+        """打完计数涨了，find_nest 就不会再吐同一个 key，正常继续。"""
+        first = NestTarget(FakeBox('0/36', y=300), 'go_nightmare:36:15')
+        after = NestTarget(FakeBox('0/48', y=400), 'go_nest:48:20')
+        task = self._task_with_nests([first])
+
+        self.assertIs(task._next_nest_with_progress(), first)
+        task._pending[:] = [after]                       # 计数涨了，换成别的目标
+        self.assertIs(task._next_nest_with_progress(), after)
+        self.assertEqual(set(), task._unreachable_nests)
+
+    def test_attempt_memory_is_cleared_between_runs(self):
+        """上一轮拉黑的巢穴，下一轮（比如第二天）要重新给机会。"""
+        task = NightmareNestTask.__new__(NightmareNestTask)
+        task._unreachable_nests = {'go_nightmare:36:15'}
+        task._attempted_nests = {'go_nightmare:36:15'}
+
+        source = Path('src/task/NightmareNestTask.py').read_text(encoding='utf-8')
+        for method in ('def run(self):', 'def run_capture_mode(self):'):
+            start = source.index(method)
+            body = source[start:start + 600]
+            self.assertIn('self._unreachable_nests.clear()', body)
+            self.assertIn('self._attempted_nests.clear()', body)
+
 
 
 if __name__ == '__main__':

--- a/tests/TestNightmareNestTask.py
+++ b/tests/TestNightmareNestTask.py
@@ -26,6 +26,7 @@ class TestNightmareNestTask(unittest.TestCase):
 
     def test_capture_success_clears_combat_before_post_combat_waits(self):
         task = NightmareNestTask.__new__(NightmareNestTask)
+        task.config = {}
         task._capture_mode = True
         task._in_combat = True
         picked = []
@@ -49,6 +50,7 @@ class TestNightmareNestTask(unittest.TestCase):
         for feature_name in ('team_close', 'fast_travel_custom'):
             with self.subTest(feature_name=feature_name):
                 task = NightmareNestTask.__new__(NightmareNestTask)
+                task.config = {}
                 task._capture_mode = False
                 task._capture_success = False
                 combat_calls = []
@@ -77,6 +79,7 @@ class TestNightmareNestTask(unittest.TestCase):
 
     def test_capture_mode_does_not_check_combat_after_pickup(self):
         task = NightmareNestTask.__new__(NightmareNestTask)
+        task.config = {}
         task._capture_mode = True
         task.wait_combat = lambda **kwargs: self.fail('capture mode should leave after obtaining an echo')
 
@@ -84,6 +87,7 @@ class TestNightmareNestTask(unittest.TestCase):
 
     def test_unreachable_nest_is_cached_when_travel_does_not_enter_world(self):
         task = NightmareNestTask.__new__(NightmareNestTask)
+        task.config = {}
         task._unreachable_nests = set()
         backs = []
         clicks = []
@@ -109,6 +113,7 @@ class TestNightmareNestTask(unittest.TestCase):
 
     def test_travel_waits_up_to_120_seconds_for_loading(self):
         task = NightmareNestTask.__new__(NightmareNestTask)
+        task.config = {}
         task._unreachable_nests = set()
         travel = FakeBox('fast_travel_custom')
         world_waits = []
@@ -123,6 +128,7 @@ class TestNightmareNestTask(unittest.TestCase):
 
     def test_find_nest_skips_cached_unreachable_row(self):
         task = NightmareNestTask.__new__(NightmareNestTask)
+        task.config = {}
         task.count_re = re.compile(r"(\d{1,2})/(\d{1,2})")
         task.queues = [lambda: None]
         task._unreachable_nests = {'<lambda>:36:10'}
@@ -152,6 +158,7 @@ class TestNightmareNestTask(unittest.TestCase):
 
     def test_cache_key_ignores_small_ocr_position_jitter(self):
         task = NightmareNestTask.__new__(NightmareNestTask)
+        task.config = {}
         task.queues = [lambda: None]
         task.height_of_screen = lambda value: 1000 * value
 
@@ -167,6 +174,7 @@ class TestNightmareNestTask(unittest.TestCase):
         巢穴会被反复吐出来——这里照这个语义来。
         """
         task = NightmareNestTask.__new__(NightmareNestTask)
+        task.config = {}
         task._unreachable_nests = set()
         task._attempted_nests = set()
         task.logs = []
@@ -229,6 +237,7 @@ class TestNightmareNestTask(unittest.TestCase):
     def test_partially_farmed_nest_is_still_offered(self):
         """打过一部分的点位要能接着打——原来只认「已击败 0/N」。"""
         task = NightmareNestTask.__new__(NightmareNestTask)
+        task.config = {}
         task.queues = [lambda: None]
         task.count_re = re.compile(r"(\d{1,2})/(\d{1,2})")
         task._unreachable_nests = set()
@@ -261,6 +270,7 @@ class TestNightmareNestTask(unittest.TestCase):
     def test_attempt_memory_is_cleared_between_runs(self):
         """上一轮拉黑的巢穴，下一轮（比如第二天）要重新给机会。"""
         task = NightmareNestTask.__new__(NightmareNestTask)
+        task.config = {}
         task._unreachable_nests = {'go_nightmare:36:15'}
         task._attempted_nests = {'go_nightmare:36:15'}
 
@@ -275,3 +285,71 @@ class TestNightmareNestTask(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class TestOnlyFarmTheseNests(unittest.TestCase):
+    """只刷指定点位。判据来自 2026-08-27 在游戏里量到的真实坐标：
+
+        落渊南丘残象聚落  y=300 h=35  -> 行中心 317.5
+        已击败残象：0/41  y=373 h=30  -> 行中心 388.0   差 70.5px ≈ 2.35 行高
+        下一个点位 盲望之塌 y=523                距南丘名字 148px ≈ 4.9 行高
+    """
+
+    def _task(self, only, boxes):
+        task = NightmareNestTask.__new__(NightmareNestTask)
+        task.config = {'Only Farm These Nests': only}
+        task._unreachable_nests = set()
+        task._attempted_nests = set()
+        task.queues = []
+        task.count_re = re.compile(r"(\d{1,2})/(\d{1,2})")
+        task.log_info = lambda *a, **k: None
+        task.log_debug = lambda *a, **k: None
+        task.logged = []
+        task.log_error = lambda msg, **k: task.logged.append(msg)
+        task.sleep = lambda *a, **k: None
+        task.width_of_screen = lambda r: int(1920 * r)
+        task.height_of_screen = lambda r: int(1080 * r)
+
+        def fake_ocr(*a, **k):
+            m = k.get('match')
+            if m is None:
+                return boxes
+            # 上游的 ocr(match=...) 收字符串时是**精确相等**——
+            # 这正是「落渊南丘」对不上「落渊南丘残象聚落」的原因，
+            # 测试里必须照实模拟，否则测不出这个 bug。
+            if hasattr(m, 'search'):
+                return [b for b in boxes if m.search(b.name)]
+            return [b for b in boxes if b.name == m]
+
+        task.ocr = fake_ocr
+        return task
+
+    def _list_boxes(self):
+        return [FakeBox('落渊南丘残象聚落', x=890, y=300, height=35),
+                FakeBox('已击败残象：0/41', x=890, y=373, height=30),
+                FakeBox('盲望之塌残象聚落', x=890, y=523, height=31),
+                FakeBox('已击败残象：0/48', x=890, y=594, height=31)]
+
+    def test_matches_by_substring_not_exact_name(self):
+        task = self._task('落渊南丘', self._list_boxes())
+        self.assertTrue(task._wanted_nest_rows())
+
+    def test_counter_two_rows_below_the_name_still_pairs_up(self):
+        task = self._task('落渊南丘', self._list_boxes())
+        nest = task.find_nest()
+        self.assertIsNotNone(nest)
+
+    def test_does_not_bleed_into_the_next_nest(self):
+        task = self._task('落渊南丘', self._list_boxes())
+        self.assertEqual(1, len(task._wanted_nest_rows()))
+
+    def test_unconfigured_keeps_original_behaviour(self):
+        task = self._task('', self._list_boxes())
+        self.assertIsNone(task._wanted_nest_rows())
+
+    def test_name_absent_from_list_is_reported_not_swallowed(self):
+        # 「名字配错了」和「点位已打满」后果一样（什么都不刷），
+        # 但原因完全不同，必须报出来而不是默默跳过。
+        task = self._task('不存在的点位', self._list_boxes())
+        self.assertEqual([], task._wanted_nest_rows())
+        self.assertTrue(any('没找到指定的点位' in m for m in task.logged))


### PR DESCRIPTION
## 问题

`NightmareNestTask` 在两种情况下会停止工作，且均无报错：

1. `find_nest()` 仅选取计数为 `0/N` 的点位。任何一个点位只要击败过一只残象，
   便永远不会再被选中。实测四个残象聚落停留在 10/41、6/48、48/48、24/24 时，
   任务每轮都判定「没有可刷的点位」并直接结束，其中两个未打满的点位均被该条件排除。
2. 队伍无法通过挑战时，游戏弹出「挑战失败」界面。该界面未被识别，
   任务退出后会再次进入同一点位，形成无限循环。

## 修改内容

**1. 允许续刷未打满的点位**

将 `numerator == '0'` 的条件移除，仅保留 `numerator != denominator`。
打满的点位本就会被后者排除。

**2. 以结果而非界面识别失败**

不为「挑战失败」界面增加模板（模板会随版本更新失效），改为按结果判定：
同一点位在本轮已尝试过一次、计数没有变化又被再次选中时，视为无法推进，
放入已有的 `_unreachable_nests` 集合并跳过。`run()` 与 `run_capture_mode()`
开始时会清空该记录，因此下一轮运行仍会重新尝试。

**3. 新增可选配置「Only Farm These Nests」（只刷指定点位）**

对应 #1622 的需求。填写点位名称（支持子串、逗号分隔多个），留空则维持原行为。

实现中处理了三个必须解决的问题，判据均来自 1920×1080 分辨率下的实测：

- **列表需要渲染时间**：打开列表后立即 OCR 会读不到任何文字。
  现改为等待至能读出任意一个 `x/y` 计数为止（上限 15 秒）。
- **名称需按子串匹配**：游戏内显示「落渊南丘残象聚落」，用户通常配置「落渊南丘」，
  `ocr(match=<str>)` 为精确匹配，无法命中。
- **名称与计数不在同一行**：

  ```
  落渊南丘残象聚落  y=300 h=35 → 行中心 317.5
  已击败残象：0/41  y=373 h=30 → 行中心 388.0（相差 70.5px ≈ 2.35 行高）
  相邻点位 盲望之塌  y=523（距上一点位名称 148px ≈ 4.9 行高）
  ```

  配对窗口取名称下方 4 个行高：覆盖 2.35，且不会误取相邻点位（4.9）的计数。

当配置的名称确实不在列表中时，通过 `log_error(notify=True)` 明确报告，
并附上实际识别到的文字，便于与「所有点位均已打满」区分——两者行为相同
（均不刷取），原因完全不同。

## 测试

`tests/TestNightmareNestTask.py` 共 19 个用例，覆盖上述三处及原有行为，
已在 Windows 实机环境使用项目自带的 Python 全部通过。
原有用例以 `__new__` 构造对象且未设置 `config`，`find_nest` 现会读取该属性，
故为其补充了空字典（等同于未配置，行为不变）。