### PR TITLE
fix(daily): 附加任务先于领奖执行，避免其产生的奖励无法领取

### DIFF
--- a/src/task/DailyTask.py
+++ b/src/task/DailyTask.py
@@ -127,12 +127,17 @@ class DailyTask(WWOneTimeTask, BaseCombatTask):
                                                                        config=self.config)
             self.sleep(4)
 
+        # Additional tasks run before the rewards are claimed. With the
+        # original order, anything an additional task finishes - the weekly
+        # garden most obviously - leaves rewards nothing will ever collect,
+        # because claiming already happened.
+        self.run_additional_tasks()
+
         self.claim_daily()
 
         self.claim_mail()
         self.sleep(1)
         self.claim_battle_pass()
-        self.run_additional_tasks()
         self.log_info('Daily Task Completed', notify=True)
 
     def validate_additional_tasks(self):

--- a/tests/TestDailyTaskRewardOrder.py
+++ b/tests/TestDailyTaskRewardOrder.py
@@ -1,0 +1,30 @@
+import inspect
+import unittest
+
+from src.task.DailyTask import DailyTask
+
+
+class TestDailyTaskRewardOrder(unittest.TestCase):
+    """Additional tasks must run before the rewards are claimed.
+
+    The weekly garden is the obvious case: it is an additional task, and
+    finishing it leaves rewards on the daily screen. With claiming done
+    first, those rewards are never collected - there is no second pass.
+
+    run() cannot be driven without a live game, and the guarantee here is
+    purely about ordering, so the assertion is made against the source of
+    run() itself.
+    """
+
+    def test_additional_tasks_run_before_claiming(self):
+        src = inspect.getsource(DailyTask.run)
+        self.assertLess(src.index('self.run_additional_tasks()'),
+                        src.index('self.claim_daily()'),
+                        'run_additional_tasks() must come before claim_daily()')
+
+    def test_claiming_is_still_last(self):
+        src = inspect.getsource(DailyTask.run)
+        for name in ('self.claim_daily()', 'self.claim_mail()',
+                     'self.claim_battle_pass()'):
+            self.assertLess(src.index('self.run_additional_tasks()'),
+                            src.index(name), f'{name} must come after')


### PR DESCRIPTION
## 问题

`DailyTask.run()` 中 `run_additional_tasks()` 排在 `claim_daily()` /
`claim_mail()` / `claim_battle_pass()` 之后。附加任务完成后产生的奖励
因此没有机会被领取——领取步骤已经执行完毕，流程中没有第二次领取。

最直接的例子是周常乐园：它作为附加任务执行，完成后日常奖励才变为可领取状态，
按当前顺序，该奖励每次都会被跳过。

## 修改内容

将 `run_additional_tasks()` 移至三个领取步骤之前。领取应当位于流程末尾，
没有任务需要在领取之后执行。

## 测试

新增 `tests/TestDailyTaskRewardOrder.py`：断言 `run()` 源码中
`run_additional_tasks()` 位于三个 `claim_*()` 之前。`run()` 依赖真实游戏环境，
无法在单元测试中完整执行，而本修改需要保证的正是调用顺序，
因此直接对源码顺序作断言。

本地环境已应用此改动并随每日任务运行，周常乐园完成后的奖励可正常领取。