### PR TITLE
fix(combat): 修复两名辅助无限互切、主C始终无法上场的死锁

### DIFF
--- a/src/task/BaseCombatTask.py
+++ b/src/task/BaseCombatTask.py
@@ -499,9 +499,33 @@ class BaseCombatTask(CombatCheck):
                 return target
         return None
 
+    # When the concerto bar never fills, has_buff() stays False for everyone,
+    # so _unbuffed_non_main_target keeps handing the turn back and forth
+    # between the two supports and the main DPS never gets on screen. The main
+    # DPS is the one character who could build concerto in the first place, so
+    # the deadlock sustains itself: the fight runs its full duration with the
+    # main DPS at zero uptime. Reported in #1626.
+    #
+    # The escape hatch is deliberately narrow: only when the character on
+    # screen is not the main DPS, and only after the main DPS has been off
+    # screen for longer than a normal rotation would ever leave it.
+    MAIN_DPS_STARVE_SECONDS = 25.0
+
+    def _starved_main_dps_target(self, candidates):
+        now = time.time()
+        starved = [char for char in candidates
+                   if char.is_main_dps
+                   and (char.last_switch_in_time < 0
+                        or now - char.last_switch_in_time > self.MAIN_DPS_STARVE_SECONDS)]
+        return self._oldest_switch_target(starved)
+
     def _choose_switch_target_by_buff_time(self, current_char, candidates):
         if not candidates:
             return current_char
+
+        if not current_char.is_main_dps:
+            if starved := self._starved_main_dps_target(candidates):
+                return starved
 
         if current_char.is_main_dps:
             lowest_buff_remaining = self._lowest_buff_remaining_target(candidates)

--- a/tests/TestMainDpsStarvation.py
+++ b/tests/TestMainDpsStarvation.py
@@ -1,0 +1,76 @@
+import time
+import unittest
+
+from src.task.BaseCombatTask import BaseCombatTask
+
+
+class FakeChar:
+
+    def __init__(self, index, role, last_switch_in_time, buff=False,
+                 buff_time=5):
+        self.index = index
+        self.char_type = role
+        self.is_main_dps = role == 'MainDps'
+        self.is_healer = role == 'Healer'
+        self.is_sub_dps = role == 'SubDps'
+        self.last_switch_in_time = last_switch_in_time
+        self.buff_time = buff_time
+        self._buff = buff
+
+    def has_buff(self):
+        return self._buff
+
+    def __repr__(self):
+        return f'{self.char_type}#{self.index}'
+
+
+class TestMainDpsStarvation(unittest.TestCase):
+    """When concerto never fills, the two supports swap forever.
+
+    `_unbuffed_support_target` picks whichever support lacks its buff. With
+    the bar stuck, that is always one of them, so the main DPS - the only
+    character able to build concerto - never gets on screen and the deadlock
+    keeps itself alive. #1626.
+    """
+
+    def _task(self):
+        task = BaseCombatTask.__new__(BaseCombatTask)
+        return task
+
+    def test_starved_main_dps_is_pulled_in(self):
+        now = time.time()
+        task = self._task()
+        main = FakeChar(1, 'MainDps', now - 60)          # off screen a minute
+        healer = FakeChar(2, 'Healer', now - 1)
+        sub = FakeChar(3, 'SubDps', now - 2)
+        target = task._choose_switch_target_by_buff_time(healer, [main, healer, sub])
+        self.assertIs(main, target)
+
+    def test_main_dps_on_screen_is_left_alone(self):
+        now = time.time()
+        task = self._task()
+        main = FakeChar(1, 'MainDps', now - 60)
+        healer = FakeChar(2, 'Healer', now - 1)
+        # 主C自己在场时不该被这条兜底影响，照常走原有逻辑。
+        target = task._choose_switch_target_by_buff_time(main, [main, healer])
+        self.assertIsNot(main, target)
+
+    def test_recently_used_main_dps_is_not_forced_in(self):
+        now = time.time()
+        task = self._task()
+        main = FakeChar(1, 'MainDps', now - 3)           # just had its turn
+        healer = FakeChar(2, 'Healer', now - 1)
+        target = task._choose_switch_target_by_buff_time(healer, [main, healer])
+        self.assertIsNot(main, target)
+
+    def test_never_switched_in_counts_as_starved(self):
+        # last_switch_in_time < 0 means "has not been on screen at all".
+        task = self._task()
+        main = FakeChar(1, 'MainDps', -1)
+        healer = FakeChar(2, 'Healer', time.time() - 1)
+        self.assertIs(main, task._starved_main_dps_target([main, healer]))
+
+    def test_no_candidates_returns_current(self):
+        task = self._task()
+        healer = FakeChar(2, 'Healer', time.time())
+        self.assertIs(healer, task._choose_switch_target_by_buff_time(healer, []))


### PR DESCRIPTION
关联 #1626。

## 问题

协奏能量无法攒满时，所有角色的 `has_buff()` 恒为 `False`。
`_unbuffed_non_main_target` 因此总能找到一名「未获得增益的辅助」，
出场权在两名辅助之间无限交替，主 C 始终无法上场。
而主 C 正是唯一能够积攒协奏能量的角色，死锁因此自我维持：
战斗持续全程，主 C 出场时间为零。

## 修改内容

在 `_choose_switch_target_by_buff_time` 起始处增加一条范围收窄的兜底逻辑：

- 仅当当前在场角色不是主 C 时生效；
- 仅当主 C 离场时间超过 `MAIN_DPS_STARVE_SECONDS = 25` 秒，
  或从未出场（`last_switch_in_time < 0`）时生效。

正常轮换不会使主 C 离场超过 25 秒，因此该逻辑在正常战斗中不会被触发。

## 测试

新增 `tests/TestMainDpsStarvation.py`，共 5 个用例：

- 主 C 离场 60 秒 → 被切换回场；
- 主 C 在场 → 不受影响，维持原有逻辑；
- 主 C 3 秒前刚下场 → 不强制切换；
- `last_switch_in_time < 0`（从未出场）→ 视为需要切入；
- 候选列表为空 → 返回当前角色（与原行为一致）。

已在 Windows 实机环境使用项目自带的 Python 全部通过。
应用此修改后，#1626 中描述的配队从「主 C 零出场」恢复为正常轮换。