### PR TITLE
fix: restart mouse reset loop when the task is re-enabled (#1569)

### DIFF
--- a/src/task/MouseResetTask.py
+++ b/src/task/MouseResetTask.py
@@ -17,20 +17,45 @@ class MouseResetTask(TriggerTask):
         self.description = "Turn on if you mouse jumps around"
         self.running_reset = False
         self.mouse_pos = None
+        self.reset_loop_id = 0
+
+    def enable(self):
+        super().enable()
+        self.start_reset()
+
+    def disable(self):
+        super().disable()
+        self.stop_reset('disabled')
 
     def run(self):
         if self.is_browser():
             return
-        if self.enabled:
-            if not self.running_reset:
-                logger.info('start mouse reset')
-                self.running_reset = True
-                self.handler.post(self.mouse_reset, 0.01)
-        else:
-            self.running_reset = False
+        if self.enabled and not self.running_reset:
+            self.start_reset()
 
-    def mouse_reset(self):
+    def start_reset(self):
+        if self.running_reset:
+            return
+        logger.info('start mouse reset')
+        self.running_reset = True
+        # bump the loop id so callbacks from a previous loop are ignored
+        self.reset_loop_id += 1
+        loop_id = self.reset_loop_id
+        self.handler.post(lambda: self.mouse_reset(loop_id), 0.01)
+
+    def stop_reset(self, reason):
+        if self.running_reset:
+            logger.info(f'mouse reset stopped: {reason}')
+        self.mouse_pos = None
+        self.running_reset = False
+        # invalidate callbacks still queued from the stopped loop
+        self.reset_loop_id += 1
+
+    def mouse_reset(self, loop_id):
+        if loop_id != self.reset_loop_id or not self.enabled:
+            return
         if self.is_browser():
+            self.handler.post(lambda: self.mouse_reset(loop_id), 1)
             return
         try:
             current_position = win32api.GetCursorPos()
@@ -49,11 +74,10 @@ class MouseResetTask(TriggerTask):
                     logger.info(f'move mouse back {self.mouse_pos}')
                     win32api.SetCursorPos(self.mouse_pos)
                     self.mouse_pos = self.mouse_pos
-                    if self.enabled:
-                        self.handler.post(self.mouse_reset, 1)
+                    self.handler.post(lambda: self.mouse_reset(loop_id), 1)
                     return
             self.mouse_pos = current_position
-            if self.enabled:
-                return self.handler.post(self.mouse_reset, 0.002)
+            self.handler.post(lambda: self.mouse_reset(loop_id), 0.002)
         except Exception as e:
             logger.error('mouse_reset exception', e)
+            self.handler.post(lambda: self.mouse_reset(loop_id), 1)

--- a/tests/TestMouseResetTask.py
+++ b/tests/TestMouseResetTask.py
@@ -1,0 +1,115 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ok import TriggerTask
+
+from src.task.MouseResetTask import MouseResetTask
+
+
+def parent_disable(self):
+    self._enabled = False
+
+
+def parent_enable(self):
+    self._enabled = True
+
+
+class FakeHandler:
+    """Records handler.post calls instead of scheduling them on a thread."""
+
+    def __init__(self):
+        self.posts = []
+
+    def post(self, task, delay=0, remove_existing=False, skip_if_running=False):
+        self.posts.append((task, delay))
+        return True
+
+    def pop(self):
+        return self.posts.pop(0)[0]
+
+
+class TestMouseResetTask(unittest.TestCase):
+
+    def make_task(self):
+        task = MouseResetTask(MagicMock(), None)
+        task._handler = FakeHandler()
+        task._enabled = True
+        return task
+
+    def test_run_starts_loop_once(self):
+        task = self.make_task()
+        task.run()
+        self.assertTrue(task.running_reset)
+        self.assertEqual(len(task.handler.posts), 1)
+        task.run()
+        self.assertEqual(len(task.handler.posts), 1)
+
+    def test_run_while_disabled_does_nothing(self):
+        task = self.make_task()
+        task._enabled = False
+        task.run()
+        self.assertFalse(task.running_reset)
+        self.assertEqual(len(task.handler.posts), 0)
+
+    def test_disable_then_enable_restarts_loop(self):
+        task = self.make_task()
+        task.run()
+        first_callback = task.handler.pop()
+
+        with patch.object(TriggerTask, 'disable', parent_disable):
+            task.disable()
+        self.assertFalse(task.running_reset)
+        self.assertIsNone(task.mouse_pos)
+
+        # a callback queued before the disable must not revive the loop
+        first_callback()
+        self.assertEqual(len(task.handler.posts), 0)
+
+        with patch.object(TriggerTask, 'enable', parent_enable):
+            task.enable()
+        self.assertTrue(task.running_reset)
+        self.assertEqual(len(task.handler.posts), 1)
+        second_callback = task.handler.pop()
+
+        # the restarted loop keeps rescheduling itself
+        with patch('src.task.MouseResetTask.win32api') as win32api:
+            win32api.GetCursorPos.return_value = (100, 100)
+            second_callback()
+        self.assertEqual(len(task.handler.posts), 1)
+
+        # the callback from the stopped loop is still dead
+        first_callback()
+        self.assertEqual(len(task.handler.posts), 1)
+
+    def test_disable_without_loop_is_safe(self):
+        task = self.make_task()
+        with patch.object(TriggerTask, 'disable', parent_disable):
+            task.disable()
+        self.assertFalse(task.running_reset)
+        self.assertEqual(len(task.handler.posts), 0)
+
+    def test_exception_keeps_loop_alive(self):
+        task = self.make_task()
+        task.run()
+        callback = task.handler.pop()
+        with patch('src.task.MouseResetTask.win32api') as win32api:
+            win32api.GetCursorPos.side_effect = OSError('boom')
+            callback()
+        self.assertTrue(task.running_reset)
+        self.assertEqual(len(task.handler.posts), 1)
+        self.assertEqual(task.handler.posts[0][1], 1)
+
+    def test_browser_mode_reposts_slowly(self):
+        task = self.make_task()
+        task.run()
+        callback = task.handler.pop()
+        task.executor.device_manager.get_preferred_device.return_value = {'device': 'browser'}
+        with patch('src.task.MouseResetTask.win32api') as win32api:
+            callback()
+            win32api.GetCursorPos.assert_not_called()
+        self.assertEqual(len(task.handler.posts), 1)
+        self.assertEqual(task.handler.posts[0][1], 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 问题

#1569 鼠标恢复（MouseResetTask）关闭后重新开启不生效，直到重启应用才恢复。

## 根因

executor 只在任务 enabled 时才会调用 `run()`（ok-script `TaskExecutor` 的调度逻辑），所以旧代码 `run()` 里的 `else: running_reset = False` 分支永远不会执行。禁用后回调循环死亡，但 `running_reset` 残留为 True；重新启用时 `run()` 认为"已在运行"，不再重启循环，功能静默失效。

## 改动

- `disable()` 清理循环状态并递增 loop id，使仍在队列里的旧回调失效（杜绝 enable/disable 竞态下出现重复循环）
- `enable()` 立即重启循环，不再等待下一次触发
- 循环在 GetCursorPos 瞬时异常后以 1s 退避重试；浏览器设备模式下以 1s 慢速空转重排。不会再滞留在 `running_reset=True` 的死状态
- 新增单测覆盖：重启、去重、异常存活、浏览器模式路径

## 测试

- 新增 6 个单测（`tests/TestMouseResetTask.py`）全部通过
- 变异验证：对旧实现跑同一组测试，3/6 失败，证明测试并非空转
- CI 将在 windows-latest 上以 unittest 跑 `tests/*.py`

Fixes #1569