### PR TITLE
fix:修复讨伐强敌/战歌重奏 boss 定位全滚到底的回退 (#1605 引入)

### DIFF
--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -1178,7 +1178,7 @@ class BaseWWTask(BaseTask):
             calib_cross = get_cross_count(structure, serial_number) if structure else 0
             calib_container_h = (bar_bottom - bar_top - (len(structure) - 1) * header_h) if structure else (bar_bottom - bar_top)
             calib_item_h = calib_container_h / total_number if total_number else 0
-            calib_y = min(bar_top + calib_item_h * serial_number + calib_cross * header_h, bar_bottom) if structure else bar_bottom
+            calib_y = min(bar_top + calib_item_h * serial_number + calib_cross * header_h, bar_bottom)
             to_click_y = calib_y
             item_h = calib_item_h
             self.click(bar_x, to_click_y, after_sleep=1)


### PR DESCRIPTION
频道指出问题https://pd.qq.com/s/hedrp0m3d

问题来源于
- #1605

### 问题
- 讨伐强敌/战歌重奏的 `FarmEchoTask.teleport_to_configured_boss` 调用 `click_on_book_target(serial_number, total_number)` **不传 structure**。
- #1605 清理日志时把滚动公式结尾写成了 `if structure else bar_bottom`：structure 为 None 时点击坐标直接落到滚动条底部 `0.8806`，列表滚到最底后 `max(btns)` 点中最后一项。
- 结果：sn≤4 走免滚分支正常，**sn≥5 全部定位到错误的 boss**（日志可见 `left_click boss_proceed (2431, 1197)`，1197/1440=0.831 为底部行）。

### 修复
- 删掉该 `else bar_bottom` 分支，恢复线性公式 `bar_top + item_h * sn`（structure 为 None 时本就无地区头，无需补偿，一行改动）。

### 验证
- 2K 16:9 讨伐强敌等任务场景修复后正常工作，但是有后续问题见下一节
- 无音区全部匹配正确

### 修复后发现的后续问题

本 PR 只修复 `structure=None` 时滚动坐标被直接设为 `bar_bottom` 的回归。恢复原有线性公式后，“序号大于 4 时全部滚到最后一项”的问题消失，但逐序号测试暴露出 master 原定位算法仍存在累计错位。

2560×1440、16:9 实测结果：

| 任务 | 选择序号 | 实际定位 |
| --- | --- | --- |
| 战歌重奏 | 1-8 | 1-8，正确 |
| 战歌重奏 | 9 | 10，偏后 1 项 |
| 战歌重奏 | 10 | 10，滚动到底 |
| 讨伐强敌 | 1-8 | 1-8，正确 |
| 讨伐强敌 | 9-15 | 10-16，偏后 1 项 |
| 讨伐强敌 | 16-20 | 18-22，偏后 2 项 |
| 讨伐强敌 | 21-22 | 22，滚动到底 |
| 凝素领域 | 1-20 | 全部正确 |
| 无音清剿 | 1-19 | 全部正确 |

这些结果说明：#1638 修复了 #1605 引入的直接回归，但 master 原方法仍依赖估算滚动坐标和“点击最下方可见按钮”的假设，无法覆盖不同地区分组和列表长度。

该问题不属于本 PR 的一行回归修复范围，由后续 PR #1640 统一处理。
