### PR TITLE
feat:统一 F2 挑战列表的结构化定位与边界校正

### DIFF
--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -1178,7 +1178,7 @@ class BaseWWTask(BaseTask):
             calib_cross = get_cross_count(structure, serial_number) if structure else 0
             calib_container_h = (bar_bottom - bar_top - (len(structure) - 1) * header_h) if structure else (bar_bottom - bar_top)
             calib_item_h = calib_container_h / total_number if total_number else 0
-            calib_y = min(bar_top + calib_item_h * serial_number + calib_cross * header_h, bar_bottom) if structure else bar_bottom
+            calib_y = min(bar_top + calib_item_h * serial_number + calib_cross * header_h, bar_bottom)
             to_click_y = calib_y
             item_h = calib_item_h
             self.click(bar_x, to_click_y, after_sleep=1)

--- a/src/task/BaseWWTask.py
+++ b/src/task/BaseWWTask.py
@@ -1151,62 +1151,133 @@ class BaseWWTask(BaseTask):
         return bar.y / self.height
 
     def click_on_book_target(self, serial_number: int, total_number: int, structure: list[int] = None):
-        def get_cross_count(structure, sn):
+        def get_cross_count(groups, sn):
             current_sum = 0
             cross_count = 0
-            for s in structure:
-                current_sum += s
+            for size in groups:
+                current_sum += size
                 if sn > current_sum:
                     cross_count += 1
                 else:
                     break
             return cross_count
 
+        def infer_visible_end_offset(buttons):
+            if not structure or len(buttons) < 2:
+                return None
+
+            # Button gaps are ~0.142 within a group and ~0.204 across a region header.
+            gaps = [(right.y - left.y) / self.height for left, right in zip(buttons, buttons[1:])]
+            if not all(0.12 < gap < 0.23 for gap in gaps):
+                return None
+
+            boundaries = set()
+            current_sum = 0
+            for size in structure[:-1]:
+                current_sum += size
+                boundaries.add(current_sum)
+
+            observed = tuple(gap > 0.17 for gap in gaps)
+            matches = []
+            count = len(buttons)
+            # Coarse scrollbar placement is only corrected when one adjacent window matches uniquely.
+            for offset in (-1, 0, 1):
+                end_serial = serial_number + offset
+                start_serial = end_serial - count + 1
+                if start_serial < 1 or end_serial > total_number:
+                    continue
+                expected = tuple((start_serial + index) in boundaries for index in range(count - 1))
+                if expected == observed:
+                    matches.append(offset)
+            return matches[0] if len(matches) == 1 else None
+
+        if total_number <= 0 or not 1 <= serial_number <= total_number:
+            raise ValueError(f'invalid book target: serial={serial_number}, total={total_number}')
+        if structure and (any(size <= 0 for size in structure) or sum(structure) != total_number):
+            raise ValueError(f'invalid book structure: structure={structure}, total={total_number}')
+
         self.sleep(0.5)
         bar_bottom = 0.8806
         bar_x = 0.9730
-        header_h = 0.028  # calibrated header height (~40px @1440), replaces separator=0.01
-        cross_count = 0
+        header_h = 0.028
         container_max_rows = 4
-        target_index = -1
-
+        target_index = serial_number - 1 if serial_number <= container_max_rows else -1
         bar_top = self._find_book_scroll_top()
 
-        if serial_number <= container_max_rows:
-            target_index = serial_number - 1
-        else:
-            calib_cross = get_cross_count(structure, serial_number) if structure else 0
-            calib_container_h = (bar_bottom - bar_top - (len(structure) - 1) * header_h) if structure else (bar_bottom - bar_top)
-            calib_item_h = calib_container_h / total_number if total_number else 0
-            calib_y = min(bar_top + calib_item_h * serial_number + calib_cross * header_h, bar_bottom)
-            to_click_y = calib_y
-            item_h = calib_item_h
+        if target_index < 0:
+            cross_count = get_cross_count(structure, serial_number) if structure else 0
+            container_h = ((bar_bottom - bar_top - (len(structure) - 1) * header_h)
+                           if structure else (bar_bottom - bar_top))
+            item_h = container_h / total_number
+            to_click_y = min(bar_top + item_h * serial_number + cross_count * header_h, bar_bottom)
             self.click(bar_x, to_click_y, after_sleep=1)
-        btns = self.find_feature('boss_proceed', box=self.box_of_screen(0.9113, 0.229, 0.9613, 0.861), threshold=0.8)
-        # adaptive retry: closed-loop correction for residual underscroll (found 3/4 with low max_y)
-        if not target_index > -1 and btns and len(btns) in (3, 4) and structure and serial_number > container_max_rows:
-            max_y = max(b.y / self.height for b in btns)
-            if max_y < 0.73:
-                retry_y = min(to_click_y + item_h * 0.55, bar_bottom) if 'item_h' in locals() and item_h else min(to_click_y + 0.018, bar_bottom)
-                self.click(bar_x, retry_y, after_sleep=1)
-                btns = self.find_feature('boss_proceed', box=self.box_of_screen(0.9113, 0.229, 0.9613, 0.861), threshold=0.8)
+
+        btns = self.find_feature(
+            'boss_proceed', box=self.box_of_screen(0.9113, 0.229, 0.9613, 0.861), threshold=0.8
+        )
+        btns = sorted(btns or [], key=lambda box: box.y)
         if not btns:
             raise Exception("can't find boss_proceed")
-        if target_index > -1:
-            if target_index < len(btns):
-                target = btns[target_index]
-            else:
-                # Fallback: not enough visible rows, scroll with calibrated header
-                calib_cross2 = get_cross_count(structure, serial_number) if structure else 0
-                calib_h2 = (bar_bottom - bar_top - (len(structure) - 1) * header_h) if structure else (bar_bottom - bar_top)
-                calib_y2 = min(bar_top + (calib_h2 / total_number) * serial_number + calib_cross2 * header_h, bar_bottom) if total_number else bar_bottom
-                self.click(bar_x, calib_y2, after_sleep=1)
-                btns = self.find_feature('boss_proceed', box=self.box_of_screen(0.9113, 0.229, 0.9613, 0.861), threshold=0.8)
+
+        if target_index >= 0 and target_index < len(btns):
+            target = btns[target_index]
+            selection = 'visible_index'
+            visible_end_offset = None
+        else:
+            if target_index >= 0:
+                cross_count = get_cross_count(structure, serial_number) if structure else 0
+                container_h = ((bar_bottom - bar_top - (len(structure) - 1) * header_h)
+                               if structure else (bar_bottom - bar_top))
+                item_h = container_h / total_number
+                missing_rows = serial_number - len(btns)
+                to_click_y = min(
+                    bar_top + item_h * serial_number + cross_count * header_h + missing_rows * item_h,
+                    bar_bottom,
+                )
+                self.click(bar_x, to_click_y, after_sleep=1)
+                btns = self.find_feature(
+                    'boss_proceed', box=self.box_of_screen(0.9113, 0.229, 0.9613, 0.861), threshold=0.8
+                )
+                btns = sorted(btns or [], key=lambda box: box.y)
                 if not btns:
                     raise Exception("can't find boss_proceed after scroll")
-                target = max(btns, key=lambda box: box.y)
-        else:
-            target = max(btns, key=lambda box: box.y)
+
+            visible_end_offset = infer_visible_end_offset(btns)
+            max_y = btns[-1].y / self.height
+            retry_by_signature = visible_end_offset == -1
+            retry_by_position = visible_end_offset is None and len(btns) in (3, 4) and max_y < 0.73
+            if structure and (retry_by_signature or retry_by_position):
+                retry_y = min(to_click_y + item_h * 0.55, bar_bottom)
+                reason = 'signature' if retry_by_signature else 'position'
+                self.log_info(
+                    f'[BOOK_SCROLL] retry sn={serial_number} reason={reason} '
+                    f'offset={visible_end_offset} click_y={retry_y:.5f}'
+                )
+                self.click(bar_x, retry_y, after_sleep=1)
+                btns = self.find_feature(
+                    'boss_proceed', box=self.box_of_screen(0.9113, 0.229, 0.9613, 0.861), threshold=0.8
+                )
+                btns = sorted(btns or [], key=lambda box: box.y)
+                if not btns:
+                    raise Exception("can't find boss_proceed after retry")
+                visible_end_offset = infer_visible_end_offset(btns)
+                if retry_by_signature and visible_end_offset not in (0, 1):
+                    raise RuntimeError(
+                        f'book target remains unresolved after retry: serial={serial_number}, '
+                        f'offset={visible_end_offset}'
+                    )
+
+            if visible_end_offset in (0, 1) and visible_end_offset < len(btns):
+                target = btns[-1 - visible_end_offset]
+                selection = f'boundary_offset_{visible_end_offset}'
+            else:
+                target = btns[-1]
+                selection = 'geometry_bottom'
+
+        self.log_info(
+            f'[BOOK_SCROLL] target sn={serial_number} selection={selection} '
+            f'offset={visible_end_offset} ys={[round(button.y / self.height, 5) for button in btns]}'
+        )
         self.draw_boxes(boxes=target, color="red")
         self.click(target, after_sleep=1)
         feature = self.wait_feature(['fast_travel_custom', 'gray_teleport', 'remove_custom', 'team_close'], time_out=10,

--- a/src/task/FarmEchoTask.py
+++ b/src/task/FarmEchoTask.py
@@ -56,8 +56,10 @@ class FarmEchoTask(WWOneTimeTask, BaseCombatTask):
                           'Nightmare: Hecate', 'Fenrico', 'Nameless Explorer']
         self.config_type['Boss'] = {'type': "drop_down", 'options': self.boss_list}
         self.combat_end_condition = self.find_echos
-        self.total_weekly_number = 9
-        self.total_boss_number = 20
+        self.weekly_structure = [1, 2, 3, 4]
+        self.boss_structure = [2, 4, 7, 1, 9]
+        self.total_weekly_number = sum(self.weekly_structure)
+        self.total_boss_number = sum(self.boss_structure)
         self.add_exit_after_config()
         self._has_treasure = False
         self._in_realm = False
@@ -246,17 +248,19 @@ class FarmEchoTask(WWOneTimeTask, BaseCombatTask):
             feature = 'zhange'
             serial_number = self.config.get('Which Weekly Boss to Teleport', 1)
             total_number = self.total_weekly_number
+            structure = self.weekly_structure
         elif teleport_to_boss == 'Boss Challenge':
             feature = 'qiangdi'
             serial_number = self.config.get('Which Boss Challenge to Teleport', 1)
             total_number = self.total_boss_number
+            structure = self.boss_structure
         else:
             raise RuntimeError(f'Unknown Teleport to Boss config: {teleport_to_boss}')
 
         self.info_set('Teleport to Boss', f'{teleport_to_boss} {serial_number - 1}')
         self.openF2Book('gray_book_boss')
         self.open_boss_book(feature)
-        is_team = self.click_on_book_target(serial_number, total_number)
+        is_team = self.click_on_book_target(serial_number, total_number, structure)
         if is_team:
             if teleport_to_boss == 'Weekly Challenge':
                 self.click_configured_boss_level()


### PR DESCRIPTION
Follow-up to #1638.

> **依赖关系 / Dependency**
>
> 本分支基于 PR #1638 的 head commit `a6ef9322` 创建；本 PR 的统一定位算法增量为 `a6ef9322..e5539d4d`。在 #1638 合入前，GitHub 对 `master` 的比较会暂时包含 #1638 的一行修复；#1638 合入后，本 PR 的有效 diff 将只剩统一定位改动。
> 本pr的解决问题的方法可以留到下版本观察，若能成功实现低维护目标，再考虑merge

## 修改内容 / Changes

### #1638 未覆盖的问题

#1638 修复了 `structure=None` 时滚动坐标被直接设为 `bar_bottom` 的回归，但恢复 master 原线性公式后，逐序号测试仍发现累计错位：

- 战歌重奏：1-8 正确，9 定位到 10。
- 讨伐强敌：1-8 正确，9-15 偏后 1 项，16-20 偏后 2 项，末段滚动到底。
- 凝素领域和无音清剿在同轮测试中正确。

master 原方法根据列表总数和固定几何估算滚动位置，滚动后通常直接点击最下方可见的 `boss_proceed`。它没有判断当前可见按钮分别对应哪个全局序号，因此地区标题、列表长度和可见行数产生的误差会累积成错位。

### 本次修复

- 为四类任务提供真实地区结构，列表总数由结构自动计算。
- 保留原几何公式作为粗定位，再根据实际 `boss_proceed` 按钮间距识别当前可见的地区边界。
- 将可见边界与 `structure` 的累计边界匹配，仅在目标附近存在唯一结果时修正点击行。
- 对明确欠滚的场景进行一次有限重试；重试后仍无法确定目标时安全中止，避免静默错点。
- 不使用任务名称或特定序号修正。

### 统一数据模型：后续同类列表增减目标时，只需更新对应 `structure`；总数和地区边界会自动派生

四类任务使用相同的 F2 列表、滚动条和 `boss_proceed` 按钮布局；任务差异由地区分组数据描述：

| 任务 | 地区结构 | 总数 |
| --- | --- | ---: |
| 无音清剿 | `[2, 5, 5, 7]` | 19 |
| 凝素领域 | `[5, 5, 5, 5]` | 20 |
| 战歌重奏 | `[1, 2, 3, 4]` | 10 |
| 讨伐强敌 | `[2, 4, 7, 1, 9]` | 23 |

## 测试 / Testing

测试环境：2560×1440，16:9。
测试游戏版本：3.6
测试okww版本：3.6.6

| 任务 | 全量范围 | 当前状态 |
| --- | ---: | --- |
| 无音清剿 | 1-19 | 19/19 通过 |
| 凝素领域 | 1-20 | 20/20 通过 |
| 战歌重奏 | 1-10 | 10/10 通过 |
| 讨伐强敌 | 1-23 | 23/23 通过 |

已测场景未出现错误目标或 unresolved 异常。

静态验证：

- Python 3.12 `py_compile` 通过。
- `git diff --check` 通过。
- 相对 #1638 的增量仅包含 `BaseWWTask.py` 和 `FarmEchoTask.py`，共 `+115/-40`。

## 修改类型 / Type of change

- [x] Bug fix（修复问题且不会破坏现有功能）
- [x] New feature（新增功能且不会破坏现有功能）
- [ ] Breaking change（会导致现有功能无法正常工作的修复或功能）
- [ ] Documentation update（文档更新）

## 是否属于重大变更 / Is this a major change?

- [x] 是 / Yes
- [ ] 否 / No

## 检查清单 / Checklist

- [x] 我的代码遵循了本项目的样式指南
- [x] 我已经进行了自我审查
- [x] 我已对难以理解的区域添加了注释
- [x] 我的更改不会产生新的警告
- [x] 四类任务的 72 项全量游戏内测试已全部完成
