### PR TITLE
fix(nest): 允许续刷未打满的残象聚落点位

### DIFF
--- a/src/task/NightmareNestTask.py
+++ b/src/task/NightmareNestTask.py
@@ -214,7 +214,7 @@ class NightmareNestTask(WWOneTimeTask, BaseCombatTask):
             for match in re.finditer(self.count_re, count_box.name):
                 numerator = match.group(1)
                 denominator = match.group(2)
-                if numerator != denominator and denominator in ['24', '36', '48', '41'] and numerator == '0':
+                if numerator != denominator and denominator in ['24', '36', '48', '41']:
                     cache_key = self._make_nest_cache_key(count_box, denominator)
                     if cache_key in self._unreachable_nests:
                         self.log_info(f'skip cached unreachable nightmare nest: {cache_key}')


### PR DESCRIPTION
`find_nest()` 里的条件带了 `numerator == '0'`：

```python
if numerator != denominator and denominator in ['24', '36', '48', '41'] and numerator == '0':
```

一个点位只要击败过一只残象，`numerator` 就不再是 `0`，此后永远不会被选中。我这边四个残象聚落分别停在 10/41、6/48、48/48、24/24 的时候，任务每轮都判定没有可刷的点位、直接结束，其中两个没打满的都是被这个条件挡掉的，而且没有任何提示，看上去就像正常跑完了。

`numerator != denominator` 本身已经把打满的点位排除掉了，`numerator == '0'` 是多余的，只会让打过一半的点位再也刷不到。这里只删掉这一个条件。

这是从 #1629 拆出来的第一块，只改一行。另外两块（打完一局计数没变就跳过、只刷指定点位）我分开处理，后者是新功能，放在 #1622 里等你的意见。

需要的话我可以补一个针对 `find_nest` 的用例。
