### PR TITLE
feat(nest): 梦魇巢穴任务新增「只刷指定点位」选项（默认为空，不改变现有行为）

### DIFF
--- a/i18n/zh_CN/LC_MESSAGES/ok.po
+++ b/i18n/zh_CN/LC_MESSAGES/ok.po
@@ -654,6 +654,12 @@ msgstr "梦魇巢穴"
 msgid "Auto Farm all Nightmare Nest"
 msgstr "自动刷所有梦魇巢穴"
 
+msgid "Only Farm These Nests"
+msgstr "只刷指定点位"
+
+msgid "Only farm nests whose name contains one of these words, matched against the in-game list. Separate several with commas. Leave empty to farm all."
+msgstr "只刷名字含有这些字的点位，按游戏里列表的文字匹配，多个用逗号隔开。留空则刷全部。"
+
 msgid "Select boss profile (includes Combat Wait Time)"
 msgstr "选择Boss配置 (已包含战斗开始前等待时间)"
 

--- a/i18n/zh_TW/LC_MESSAGES/ok.po
+++ b/i18n/zh_TW/LC_MESSAGES/ok.po
@@ -651,6 +651,12 @@ msgstr "刷夢魘·赫卡忒請選是"
 msgid "Auto Farm all Nightmare Nest"
 msgstr "自動刷所有夢魘巢穴"
 
+msgid "Only Farm These Nests"
+msgstr "只刷指定點位"
+
+msgid "Only farm nests whose name contains one of these words, matched against the in-game list. Separate several with commas. Leave empty to farm all."
+msgstr "只刷名字含有這些字的點位，按遊戲裡列表的文字匹配，多個用逗號隔開。留空則刷全部。"
+
 msgid "Other"
 msgstr "其它"
 

--- a/src/task/NightmareNestTask.py
+++ b/src/task/NightmareNestTask.py
@@ -9,6 +9,13 @@ from src.task.WWOneTimeTask import WWOneTimeTask
 logger = Logger.get_logger(__name__)
 TRAVEL_FEATURES = ['fast_travel_custom', 'gray_teleport', 'remove_custom']
 CONFIRM_FEATURES = ['confirm_btn_hcenter_vcenter', 'confirm_btn_highlight_hcenter_vcenter']
+ONLY_NESTS = 'Only Farm These Nests'
+# How long to wait for the nest list to render before reading names from it.
+NEST_LIST_TIMEOUT = 15
+# The kill count sits below the nest name inside the same card, about two rows
+# lower; the next card starts roughly five rows down. Four rows keeps a count
+# attached to its own name without reaching the next nest.
+NEST_ROW_SPAN = 4
 
 
 @dataclass
@@ -33,7 +40,11 @@ class NightmareNestTask(WWOneTimeTask, BaseCombatTask):
         self._capture_mode = False
         self._unreachable_nests = set()
         self._nest_tab_of_current_nest = 'go_nest'
-        self.default_config.update({'Which to Farm': ['Nightmare Purification', 'Tacet Discord Nest']})
+        self.default_config.update({'Which to Farm': ['Nightmare Purification', 'Tacet Discord Nest'],
+                                    ONLY_NESTS: ''})
+        self.config_description[ONLY_NESTS] = (
+            'Only farm nests whose name contains one of these words, matched against the in-game list. '
+            'Separate several with commas. Leave empty to farm all.')
         self.config_type['Which to Farm'] = {'type': "multi_selection",
                                              'options': ['Nightmare Purification', 'Tacet Discord Nest']}
 
@@ -208,9 +219,41 @@ class NightmareNestTask(WWOneTimeTask, BaseCombatTask):
     def go_nest(self):
         self.open_boss_book('canxiang')
 
+    def _wanted_nest_rows(self):
+        """Row centres (y) of the nests named in ONLY_NESTS, or None when the option is empty.
+
+        An empty list means the option is set but none of the names is on the
+        current list, so nothing should be farmed.
+        """
+        raw = ((getattr(self, 'config', None) or {}).get(ONLY_NESTS) or '').strip()
+        if not raw:
+            return None
+        names = [n.strip() for n in re.split(r'[,，]', raw) if n.strip()]
+        # The list keeps rendering for a moment after it opens; wait until a
+        # count is readable instead of a fixed delay.
+        for _ in range(NEST_LIST_TIMEOUT):
+            if self.ocr(0.35, 0.13, 1, 0.96, match=self.count_re):
+                break
+            self.sleep(1)
+        boxes = self.ocr(0.35, 0.13, 1, 0.96)
+        rows = [box.y + box.height / 2
+                for name in names for box in boxes if name in (box.name or '')]
+        if not rows:
+            self.log_error(f'nightmare nest: none of {names} found in the list, '
+                           f'got {[box.name for box in boxes]}', notify=True)
+        return rows
+
     def find_nest(self):
+        wanted_rows = self._wanted_nest_rows()
+        if wanted_rows is not None and not wanted_rows:
+            return None
         counts = self.ocr(0.35, 0.13, 1, 0.96, match=self.count_re)
         for count_box in counts:
+            if wanted_rows is not None:
+                row = count_box.y + count_box.height / 2
+                span = count_box.height * NEST_ROW_SPAN
+                if not any(-count_box.height <= row - w <= span for w in wanted_rows):
+                    continue
             for match in re.finditer(self.count_re, count_box.name):
                 numerator = match.group(1)
                 denominator = match.group(2)

--- a/tests/TestNightmareNestTask.py
+++ b/tests/TestNightmareNestTask.py
@@ -1,7 +1,7 @@
 import unittest
 import re
 
-from src.task.NightmareNestTask import NestTarget, NightmareNestTask
+from src.task.NightmareNestTask import ONLY_NESTS, NestTarget, NightmareNestTask
 
 
 class FakeBox:
@@ -15,6 +15,51 @@ class FakeBox:
 
 
 class TestNightmareNestTask(unittest.TestCase):
+
+    def test_only_farm_these_nests_empty_means_all(self):
+        task = NightmareNestTask.__new__(NightmareNestTask)
+        task.config = {ONLY_NESTS: ''}
+        self.assertIsNone(task._wanted_nest_rows())
+
+    def test_only_farm_these_nests_matches_by_substring(self):
+        task = NightmareNestTask.__new__(NightmareNestTask)
+        task.config = {ONLY_NESTS: '落渊南丘, 盲望之塌'}
+        task.count_re = re.compile(r"(\d{1,2})/(\d{1,2})")
+        task.sleep = lambda *args, **kwargs: None
+        boxes = [FakeBox('落渊南丘残象聚落', y=300, height=35),
+                 FakeBox('已击败残象：0/41', y=373, height=30),
+                 FakeBox('盲望之塌残象聚落', y=523, height=35),
+                 FakeBox('已击败残象：48/48', y=596, height=30)]
+        task.ocr = lambda *args, **kwargs: boxes if 'match' not in kwargs else [boxes[1], boxes[3]]
+        self.assertEqual([317.5, 540.5], task._wanted_nest_rows())
+
+    def test_find_nest_skips_counts_outside_wanted_nests(self):
+        task = NightmareNestTask.__new__(NightmareNestTask)
+        task.config = {ONLY_NESTS: '盲望之塌'}
+        task.count_re = re.compile(r"(\d{1,2})/(\d{1,2})")
+        task._unreachable_nests = set()
+        task.sleep = lambda *args, **kwargs: None
+        task.log_info = lambda *args, **kwargs: None
+        task.width_of_screen = lambda ratio: 1000
+        task._make_nest_cache_key = lambda box, denominator: f'{box.name}@{denominator}'
+        names = [FakeBox('落渊南丘残象聚落', y=300, height=35), FakeBox('盲望之塌残象聚落', y=523, height=35)]
+        counts = [FakeBox('已击败残象：0/41', y=373, height=30), FakeBox('已击败残象：0/48', y=596, height=30)]
+        task.ocr = lambda *args, **kwargs: counts if 'match' in kwargs else names + counts
+        nest = task.find_nest()
+        self.assertIsInstance(nest, NestTarget)
+        self.assertEqual('已击败残象：0/48@48', nest.cache_key)
+
+    def test_find_nest_returns_nothing_when_named_nest_is_absent(self):
+        task = NightmareNestTask.__new__(NightmareNestTask)
+        task.config = {ONLY_NESTS: '不存在的点位'}
+        task.count_re = re.compile(r"(\d{1,2})/(\d{1,2})")
+        task.sleep = lambda *args, **kwargs: None
+        errors = []
+        task.log_error = lambda *args, **kwargs: errors.append(args[0])
+        boxes = [FakeBox('落渊南丘残象聚落', y=300, height=35), FakeBox('已击败残象：0/41', y=373, height=30)]
+        task.ocr = lambda *args, **kwargs: [boxes[1]] if 'match' in kwargs else boxes
+        self.assertIsNone(task.find_nest())
+        self.assertEqual(1, len(errors))
 
     def test_nest_is_checked_before_nightmare_changes_book_scroll(self):
         task = NightmareNestTask.__new__(NightmareNestTask)


### PR DESCRIPTION

## 修改内容 / Changes

- `src/task/NightmareNestTask.py`：新增配置项 `Only Farm These Nests`。填点位名字里的一段（比如「落渊南丘」），多个用逗号隔开；`find_nest` 先按名字在列表里定位到那几张卡片，只认卡片下方的击败计数。留空时代码路径和原来完全一样。配置了名字但列表里一个都没找到时 `log_error(notify=True)` 并返回 None，不会静默结束。
- `i18n/zh_CN`、`i18n/zh_TW`：选项名和说明的翻译。
- `tests/TestNightmareNestTask.py`：四个测试——留空返回 None；按包含匹配定位行；计数不在指定卡片下方的被跳过；名字都不在列表时返回 None 并报错。

## 修改类型 / Type of Change

- [ ] Bug 修复 / Bug fix
- [ ] 文档或翻译 / Documentation or translation
- [ ] 小型优化或兼容性修复 / Small improvement or compatibility fix
- [x] 新功能 / New feature
- [ ] 大幅修改现有功能 / Major modification of existing behavior
- [ ] 重构或架构调整 / Refactor or architecture change

## 新功能或大改确认 / New Feature or Major Change Confirmation

- [ ] 不适用，本 PR 不是新功能或大改 / Not applicable; this PR is not a new feature or major change
- [x] 已联系作者或已在社区讨论 / I have contacted the author or discussed this in the community

相关讨论链接或联系方式说明：

- https://github.com/ok-oldking/ok-wuthering-waves/discussions/954 （自主选择刷哪些聚落，已在下面补充了这个方案）
- https://github.com/ok-oldking/ok-wuthering-waves/issues/1614 是同一类需求

## 测试 / Testing

- `tests/TestNightmareNestTask.py` 全部 12 个（上游 8 个 + 新加 4 个）在 ok-ww 自带的 Python 环境里跑过，全过。
- 同样的定位逻辑（按名字找卡片、只认下方计数）在我这台机器上以整文件补丁的形式每天跑日常，从 8 月 27 日到今天，只刷「落渊南丘残象聚落」，没有出现选错点位的情况。
- 留空的情况没有单独测：这条路径没有改动。

## 截图或录屏 / Screenshots or Recordings

不涉及界面改动。配置项在梦魇巢穴任务的设置里多一栏文本框。

## 检查清单 / Checklist

- [x] 我已阅读 [CONTRIBUTING.md](https://github.com/ok-oldking/ok-wuthering-waves/blob/master/CONTRIBUTING.md) / I have read [CONTRIBUTING.md](https://github.com/ok-oldking/ok-wuthering-waves/blob/master/CONTRIBUTING.md)
- [x] 我已阅读 README 中的免责声明 / I have read the disclaimer in the README
- [x] 我已尽量保持 PR 范围清晰，没有混入无关修改 / I have kept this PR focused and avoided unrelated changes
- [x] 我已说明测试结果或无法测试的原因 / I have described the test results or why testing was not possible
- [x] 我没有提交日志、缓存、临时文件或个人配置 / I have not committed logs, caches, temporary files, or personal settings

## 社区联系方式 / Community Contact

- 开发者群 / Developer QQ group: `926858895`
- Discord: [https://discord.gg/vVyCatEBgA](https://discord.gg/vVyCatEBgA)
